### PR TITLE
feat: data subject rights — verification, export, deletion, anonymization, notifications

### DIFF
--- a/config/artisanpack/privacy.php
+++ b/config/artisanpack/privacy.php
@@ -154,6 +154,66 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Notifications
+	|--------------------------------------------------------------------------
+	|
+	| Channels and queue used by the package's data-request notifications.
+	| Each notification key (received/verification/processing/completed/
+	| rejected/admin) may override the channel list independently.
+	|
+	*/
+	'notifications' => [
+		'queue'    => env( 'PRIVACY_NOTIFICATIONS_QUEUE', 'default' ),
+		'channels' => [ 'mail', 'database' ],
+
+		'received'     => [ 'channels' => [ 'mail', 'database' ] ],
+		'verification' => [ 'channels' => [ 'mail' ] ],
+		'processing'   => [ 'channels' => [ 'database' ] ],
+		'completed'    => [ 'channels' => [ 'mail', 'database' ] ],
+		'rejected'     => [ 'channels' => [ 'mail', 'database' ] ],
+		'admin'        => [ 'channels' => [ 'mail' ] ],
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Data Export
+	|--------------------------------------------------------------------------
+	|
+	| File storage and signed-URL settings for `DataExportService::exportToFile()`.
+	|
+	*/
+	'export' => [
+		'disk'                    => env( 'PRIVACY_EXPORT_DISK', 'local' ),
+		'directory'               => 'privacy-exports',
+		'url_ttl'                 => (int) env( 'PRIVACY_EXPORT_URL_TTL', 60 ),
+		'file_retention_minutes'  => (int) env( 'PRIVACY_EXPORT_RETENTION_MINUTES', 1440 ),
+
+		/*
+		| Per-section row cap for export collection (consent history,
+		| activity log, data-request summary). Prevents OOM for very
+		| high-volume subjects. Raise if your compliance posture requires
+		| a complete export regardless of size.
+		*/
+		'row_cap' => (int) env( 'PRIVACY_EXPORT_ROW_CAP', 10000 ),
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Identity Verification
+	|--------------------------------------------------------------------------
+	|
+	| Settings for the data subject identity-verification flow that gates
+	| access/deletion/export requests. The token is stored on the request
+	| row and confirmed via the configured channel.
+	|
+	*/
+	'verification' => [
+		'token_ttl_minutes' => (int) env( 'PRIVACY_VERIFICATION_TTL', 60 ),
+		'rate_limit'        => env( 'PRIVACY_VERIFICATION_RATE_LIMIT', '6,1' ),
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Data Deletion Strategies
 	|--------------------------------------------------------------------------
 	|
@@ -188,6 +248,14 @@ return [
 		],
 		'hash_algorithm'          => 'sha256',
 		'pseudonymization_prefix' => 'Anon_',
+
+		/*
+		| Emit an audit-log entry (Log::info on the `privacy.anonymization`
+		| channel) every time a model has at least one field anonymized.
+		| Records only model class, primary key, and column names — never
+		| the original or transformed values.
+		*/
+		'audit' => true,
 	],
 
 	/*

--- a/database/migrations/2026_06_19_000001_create_privacy_scheduled_deletions_table.php
+++ b/database/migrations/2026_06_19_000001_create_privacy_scheduled_deletions_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::create( 'privacy_scheduled_deletions', function ( Blueprint $table ): void {
+			$table->id();
+			$table->morphs( 'deletable' );
+			$table->string( 'strategy' );
+			$table->timestamp( 'scheduled_for' );
+			$table->timestamp( 'processed_at' )->nullable();
+			$table->timestamp( 'cancelled_at' )->nullable();
+			$table->string( 'cancelled_reason' )->nullable();
+			$table->unsignedBigInteger( 'requested_by' )->nullable();
+			$table->json( 'options' )->nullable();
+			$table->timestamps();
+
+			$table->index( [ 'scheduled_for', 'processed_at' ] );
+		} );
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::dropIfExists( 'privacy_scheduled_deletions' );
+	}
+};

--- a/resources/js/react/VerifyDataRequest.tsx
+++ b/resources/js/react/VerifyDataRequest.tsx
@@ -1,0 +1,113 @@
+/**
+ * VerifyDataRequest — React identity-verification component.
+ *
+ * Posts the supplied token to the package's verification endpoint and
+ * surfaces the resulting confirmation/expired/already-verified state.
+ *
+ * @since 1.0.0
+ */
+
+import { useState, type ReactNode } from 'react';
+
+export interface VerifyDataRequestProps {
+	token: string;
+	endpoint?: string;
+	csrfToken?: string;
+	fetchImpl?: typeof fetch;
+	className?: string;
+	heading?: ReactNode;
+	onVerified?: () => void;
+}
+
+type Phase = 'idle' | 'pending' | 'success' | 'expired' | 'error';
+
+function resolveCsrfToken(): string | undefined {
+	if ( typeof document === 'undefined' ) {
+		return undefined;
+	}
+
+	const meta = document.querySelector<HTMLMetaElement>( 'meta[name="csrf-token"]' );
+
+	return meta?.content;
+}
+
+export function VerifyDataRequest( props: VerifyDataRequestProps ): JSX.Element {
+	const {
+		token,
+		endpoint = `/privacy/verify/${ encodeURIComponent( token ) }`,
+		csrfToken = resolveCsrfToken(),
+		fetchImpl = fetch,
+		className = 'privacy-verify-data-request',
+		heading = 'Verify your data request',
+		onVerified,
+	} = props;
+
+	const [ phase, setPhase ] = useState<Phase>( 'idle' );
+	const [ message, setMessage ] = useState<string>( '' );
+
+	async function submit() {
+		if ( phase === 'pending' || phase === 'success' ) {
+			return;
+		}
+
+		setPhase( 'pending' );
+		setMessage( '' );
+
+		try {
+			const headers: Record<string, string> = {
+				'Accept': 'application/json',
+				'X-Requested-With': 'XMLHttpRequest',
+			};
+
+			if ( csrfToken ) {
+				headers[ 'X-CSRF-TOKEN' ] = csrfToken;
+			}
+
+			const response = await fetchImpl( endpoint, {
+				method: 'POST',
+				headers,
+				credentials: 'same-origin',
+			} );
+
+			if ( response.status === 410 || response.status === 422 ) {
+				setPhase( 'expired' );
+				setMessage( 'This verification link has expired. Please submit a new request.' );
+				return;
+			}
+
+			if ( ! response.ok ) {
+				setPhase( 'error' );
+				setMessage( 'We could not verify this request. Please try again.' );
+				return;
+			}
+
+			setPhase( 'success' );
+			setMessage( 'Your identity has been verified and your request is now being processed.' );
+			onVerified?.();
+		} catch ( e ) {
+			setPhase( 'error' );
+			setMessage( 'We could not reach the verification endpoint.' );
+		}
+	}
+
+	return (
+		<div className={ className }>
+			{ heading && <h2 className={ `${ className }__heading` }>{ heading }</h2> }
+
+			{ phase === 'success' && <p className={ `${ className }__success` }>{ message }</p> }
+			{ phase === 'expired' && <p className={ `${ className }__error` }>{ message }</p> }
+			{ phase === 'error' && <p className={ `${ className }__error` }>{ message }</p> }
+
+			{ phase !== 'success' && phase !== 'expired' && (
+				<button
+					type="button"
+					onClick={ submit }
+					disabled={ phase === 'pending' }
+					className={ `${ className }__button` }
+				>
+					{ phase === 'pending' ? 'Verifying…' : 'Confirm Identity' }
+				</button>
+			) }
+		</div>
+	);
+}

--- a/resources/js/react/index.ts
+++ b/resources/js/react/index.ts
@@ -10,6 +10,8 @@ export { ConsentPreferences } from './ConsentPreferences';
 export type { ConsentPreferencesProps } from './ConsentPreferences';
 export { DataRequestForm } from './DataRequestForm';
 export type { DataRequestFormProps, DataRequestResult, DataRequestType } from './DataRequestForm';
+export { VerifyDataRequest } from './VerifyDataRequest';
+export type { VerifyDataRequestProps } from './VerifyDataRequest';
 export { useConsent } from './useConsent';
 export type { UseConsentOptions, UseConsentResult } from './useConsent';
 export type {

--- a/resources/js/vue/VerifyDataRequest.vue
+++ b/resources/js/vue/VerifyDataRequest.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+/**
+ * VerifyDataRequest — Vue identity-verification component.
+ *
+ * Mirrors the React/Livewire flow: posts the token to the package
+ * verification endpoint and surfaces success / expired / error state.
+ *
+ * @since 1.0.0
+ */
+
+import { ref } from 'vue';
+
+interface VerifyDataRequestProps {
+	token: string;
+	endpoint?: string;
+	csrfToken?: string;
+	fetchImpl?: typeof fetch;
+	className?: string;
+	heading?: string;
+}
+
+const props = withDefaults( defineProps<VerifyDataRequestProps>(), {
+	className: 'privacy-verify-data-request',
+	heading: 'Verify your data request',
+} );
+
+const emit = defineEmits<{
+	( e: 'verified' ): void;
+}>();
+
+type Phase = 'idle' | 'pending' | 'success' | 'expired' | 'error';
+
+const phase = ref<Phase>( 'idle' );
+const message = ref( '' );
+
+function resolveCsrfToken(): string | undefined {
+	if ( typeof document === 'undefined' ) {
+		return undefined;
+	}
+
+	const meta = document.querySelector<HTMLMetaElement>( 'meta[name="csrf-token"]' );
+
+	return meta?.content;
+}
+
+async function submit() {
+	if ( phase.value === 'pending' || phase.value === 'success' ) {
+		return;
+	}
+
+	phase.value = 'pending';
+	message.value = '';
+
+	const endpoint = props.endpoint ?? `/privacy/verify/${ encodeURIComponent( props.token ) }`;
+	const csrfToken = props.csrfToken ?? resolveCsrfToken();
+	const fetchImpl = props.fetchImpl ?? fetch;
+
+	try {
+		const headers: Record<string, string> = {
+			Accept: 'application/json',
+			'X-Requested-With': 'XMLHttpRequest',
+		};
+
+		if ( csrfToken ) {
+			headers[ 'X-CSRF-TOKEN' ] = csrfToken;
+		}
+
+		const response = await fetchImpl( endpoint, {
+			method: 'POST',
+			headers,
+			credentials: 'same-origin',
+		} );
+
+		if ( response.status === 410 || response.status === 422 ) {
+			phase.value = 'expired';
+			message.value = 'This verification link has expired. Please submit a new request.';
+			return;
+		}
+
+		if ( ! response.ok ) {
+			phase.value = 'error';
+			message.value = 'We could not verify this request. Please try again.';
+			return;
+		}
+
+		phase.value = 'success';
+		message.value = 'Your identity has been verified and your request is now being processed.';
+		emit( 'verified' );
+	} catch ( e ) {
+		phase.value = 'error';
+		message.value = 'We could not reach the verification endpoint.';
+	}
+}
+</script>
+
+<template>
+	<div :class="className">
+		<h2 v-if="heading" :class="`${ className }__heading`">{{ heading }}</h2>
+
+		<p v-if="phase === 'success'" :class="`${ className }__success`">{{ message }}</p>
+		<p v-else-if="phase === 'expired'" :class="`${ className }__error`">{{ message }}</p>
+		<p v-else-if="phase === 'error'" :class="`${ className }__error`">{{ message }}</p>
+
+		<button
+			v-if="phase !== 'success' && phase !== 'expired'"
+			type="button"
+			:disabled="phase === 'pending'"
+			:class="`${ className }__button`"
+			@click="submit"
+		>
+			{{ phase === 'pending' ? 'Verifying…' : 'Confirm Identity' }}
+		</button>
+	</div>
+</template>

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -7,6 +7,7 @@
 export { default as CookieBanner } from './CookieBanner.vue';
 export { default as ConsentPreferences } from './ConsentPreferences.vue';
 export { default as DataRequestForm } from './DataRequestForm.vue';
+export { default as VerifyDataRequest } from './VerifyDataRequest.vue';
 export { useConsent } from './useConsent';
 export type { UseConsentOptions, UseConsentResult } from './useConsent';
 export type {

--- a/resources/views/livewire/verify-data-request.blade.php
+++ b/resources/views/livewire/verify-data-request.blade.php
@@ -1,0 +1,35 @@
+<div class="privacy-verify-data-request">
+	@if ( null === $dataRequest )
+		<p class="privacy-verify-data-request__error">
+			{{ __( 'Verification link is invalid or no longer available.' ) }}
+		</p>
+	@elseif ( $confirmed )
+		<p class="privacy-verify-data-request__success">
+			{{ $message ?? __( 'This request has already been verified.' ) }}
+		</p>
+	@elseif ( $expired )
+		<p class="privacy-verify-data-request__error">
+			{{ __( 'This verification link has expired. Please submit a new request.' ) }}
+		</p>
+	@else
+		<p class="privacy-verify-data-request__intro">
+			{{ __( 'Confirm you submitted request #:id (:type) to continue.', [
+				'id'   => $dataRequest->id,
+				'type' => $dataRequest->type,
+			] ) }}
+		</p>
+		<button
+			type="button"
+			wire:click="confirm"
+			wire:loading.attr="disabled"
+			class="privacy-verify-data-request__button"
+		>
+			<span wire:loading.remove>{{ __( 'Confirm Identity' ) }}</span>
+			<span wire:loading>{{ __( 'Verifying…' ) }}</span>
+		</button>
+
+		@if ( null !== $message )
+			<p class="privacy-verify-data-request__message">{{ $message }}</p>
+		@endif
+	@endif
+</div>

--- a/resources/views/verification/show.blade.php
+++ b/resources/views/verification/show.blade.php
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace( '_', '-', app()->getLocale() ) }}">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>{{ __( 'Verify Your Data Request' ) }}</title>
+	<style>
+		body { font-family: system-ui, -apple-system, sans-serif; background: #f4f4f5; margin: 0; padding: 2rem; color: #18181b; }
+		.card { max-width: 32rem; margin: 4rem auto; background: #fff; border-radius: 0.75rem; padding: 2rem; box-shadow: 0 8px 24px rgba( 0, 0, 0, 0.06 ); }
+		h1 { margin-top: 0; font-size: 1.5rem; }
+		.muted { color: #71717a; font-size: 0.875rem; }
+		button { background: #18181b; color: #fff; padding: 0.625rem 1.25rem; border: 0; border-radius: 0.5rem; font-weight: 600; cursor: pointer; }
+		button:disabled { background: #a1a1aa; cursor: not-allowed; }
+		.status { padding: 0.75rem 1rem; border-radius: 0.5rem; margin-bottom: 1rem; }
+		.status-success { background: #dcfce7; color: #14532d; }
+		.status-error { background: #fee2e2; color: #7f1d1d; }
+	</style>
+</head>
+<body>
+	<div class="card">
+		<h1>{{ __( 'Verify Your Data Request' ) }}</h1>
+
+		@if ( session( 'status' ) )
+			<div class="status status-success">{{ session( 'status' ) }}</div>
+		@endif
+
+		@if ( $errors->any() )
+			<div class="status status-error">{{ $errors->first() }}</div>
+		@endif
+
+		<p class="muted">
+			{{ __( 'Request #:id of type ":type" filed on :date.', [
+				'id'   => $dataRequest->id,
+				'type' => $dataRequest->type,
+				'date' => optional( $dataRequest->created_at )->toDayDateTimeString() ?? '',
+			] ) }}
+		</p>
+
+		@if ( null !== $dataRequest->verified_at )
+			<p>{{ __( 'This request has already been verified.' ) }}</p>
+		@elseif ( $expired )
+			<p>{{ __( 'This verification link has expired. Please submit a new data request.' ) }}</p>
+		@else
+			<form method="POST" action="{{ route( 'privacy.verification.verify', [ 'token' => $token ] ) }}">
+				@csrf
+				<p>{{ __( 'Confirm you submitted this request to continue.' ) }}</p>
+				<button type="submit">{{ __( 'Confirm Identity' ) }}</button>
+			</form>
+		@endif
+	</div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Privacy package — public web routes.
+ *
+ * Loaded by {@see \ArtisanPackUI\Privacy\PrivacyServiceProvider} under the
+ * `artisanpack.privacy.routes.prefix` prefix with the configured web
+ * middleware stack.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Http\Controllers\DataExportDownloadController;
+use ArtisanPackUI\Privacy\Http\Controllers\DataRequestVerificationController;
+use Illuminate\Support\Facades\Route;
+
+Route::get(
+	'/verify/{token}',
+	[ DataRequestVerificationController::class, 'show' ],
+)->name( 'privacy.verification.show' );
+
+Route::post(
+	'/verify/{token}',
+	[ DataRequestVerificationController::class, 'verify' ],
+)->middleware( 'throttle:privacy-verification' )->name( 'privacy.verification.verify' );
+
+Route::get(
+	'/exports/{path}',
+	DataExportDownloadController::class,
+)->where( 'path', '.*' )->name( 'privacy.exports.download' );

--- a/src/Concerns/HasPersonalData.php
+++ b/src/Concerns/HasPersonalData.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * HasPersonalData trait — marks an Eloquent model as carrying personal data
+ * the privacy package can collect for export, anonymization, or deletion.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Concerns;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+/**
+ * Apply this trait to any model whose columns should appear in data subject
+ * access/export results and that the deletion service should consider when
+ * cascading.
+ *
+ * Models can either declare `protected array $personalDataFields = []`
+ * directly, or override {@see personalDataFields()} for dynamic discovery.
+ *
+ * @since 1.0.0
+ */
+trait HasPersonalData
+{
+	/**
+	 * Columns whose values represent personal data for this model.
+	 *
+	 * Override on the consuming model — either as a property or by
+	 * overriding {@see personalDataFields()}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function personalDataFields(): array
+	{
+		return property_exists( $this, 'personalDataFields' ) ? (array) $this->personalDataFields : [];
+	}
+
+	/**
+	 * Relations the privacy services should cascade across (export,
+	 * deletion, anonymization). Override to opt in.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function personalDataRelations(): array
+	{
+		return property_exists( $this, 'personalDataRelations' ) ? (array) $this->personalDataRelations : [];
+	}
+
+	/**
+	 * Returns the model's personal data as a column → value map.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toPersonalDataArray(): array
+	{
+		$data = [];
+
+		foreach ( $this->personalDataFields() as $field ) {
+			$data[ $field ] = $this->getAttribute( $field );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Returns the personal-data payload for each related record declared in
+	 * {@see personalDataRelations()}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array<int, array<string, mixed>>>
+	 */
+	public function toPersonalDataRelationArray(): array
+	{
+		$out = [];
+
+		foreach ( $this->personalDataRelations() as $relation ) {
+			if ( ! method_exists( $this, $relation ) ) {
+				continue;
+			}
+
+			$query = $this->{$relation}();
+
+			if ( ! $query instanceof Relation ) {
+				continue;
+			}
+
+			$out[ $relation ] = $query->get()
+				->map( static function ( $record ) {
+					return method_exists( $record, 'toPersonalDataArray' )
+						? $record->toPersonalDataArray()
+						: $record->toArray();
+				} )
+				->all();
+		}
+
+		return $out;
+	}
+}

--- a/src/Events/DataExportCollecting.php
+++ b/src/Events/DataExportCollecting.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * DataExportCollecting event — fired while DataExportService assembles a
+ * subject's export payload so other packages can contribute extra data.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Listeners receive the export payload by reference and can mutate
+ * `$event->data` to append additional sections.
+ *
+ * @since 1.0.0
+ */
+class DataExportCollecting
+{
+	use Dispatchable;
+
+	/**
+	 * @param Model                $subject Data subject the export belongs to.
+	 * @param array<string, mixed> $data    Mutable export payload.
+	 */
+	public function __construct( public Model $subject, public array $data )
+	{
+	}
+}

--- a/src/Events/DataSubjectDeleted.php
+++ b/src/Events/DataSubjectDeleted.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * DataSubjectDeleted event — fired after {@see DataDeletionService} applies
+ * a deletion or anonymization strategy to a subject.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Carries the subject and the strategy that was applied (`delete`,
+ * `anonymize`, `pseudonymize`).
+ *
+ * @since 1.0.0
+ */
+class DataSubjectDeleted
+{
+	use Dispatchable;
+
+	/**
+	 * @param Model  $subject  Subject that was deleted/anonymized.
+	 * @param string $strategy Strategy applied.
+	 */
+	public function __construct( public Model $subject, public string $strategy )
+	{
+	}
+}

--- a/src/Events/DataSubjectDeletionScheduled.php
+++ b/src/Events/DataSubjectDeletionScheduled.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * DataSubjectDeletionScheduled event — fired when a deletion enters the
+ * grace period and is scheduled for future processing.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Events;
+
+use ArtisanPackUI\Privacy\Models\ScheduledDeletion;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Carries the {@see ScheduledDeletion} row so listeners can notify the
+ * subject of the cooling-off window.
+ *
+ * @since 1.0.0
+ */
+class DataSubjectDeletionScheduled
+{
+	use Dispatchable;
+
+	public function __construct( public ScheduledDeletion $scheduledDeletion )
+	{
+	}
+}

--- a/src/Http/Controllers/DataExportDownloadController.php
+++ b/src/Http/Controllers/DataExportDownloadController.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * DataExportDownloadController — streams a previously generated export file
+ * to the data subject via Laravel's temporary signed URLs.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Single-action controller that validates the signed link, checks the
+ * sidecar expiry marker, and streams the file from the configured disk.
+ *
+ * @since 1.0.0
+ */
+class DataExportDownloadController extends Controller
+{
+	/**
+	 * Handle the download request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 * @param  string   $path    Stored file path (passed via signed URL).
+	 *
+	 * @return StreamedResponse
+	 */
+	public function __invoke( Request $request, string $path ): StreamedResponse
+	{
+		abort_unless( $request->hasValidSignature(), 403, 'Invalid or expired download link.' );
+
+		$directory = trim( (string) config( 'artisanpack.privacy.export.directory', 'privacy-exports' ), '/' );
+
+		abort_if(
+			str_contains( $path, '..' ) || ! str_starts_with( $path, $directory . '/' ),
+			403,
+			'Refusing to serve a path outside the configured export directory.',
+		);
+
+		$disk = (string) config( 'artisanpack.privacy.export.disk', 'local' );
+
+		abort_unless( Storage::disk( $disk )->exists( $path ), 404 );
+
+		if ( Storage::disk( $disk )->exists( $path . '.expires' ) ) {
+			$expiresAt = (string) Storage::disk( $disk )->get( $path . '.expires' );
+
+			if ( '' !== $expiresAt && Carbon::parse( $expiresAt )->isPast() ) {
+				abort( 410, 'Export file has expired.' );
+			}
+		}
+
+		return Storage::disk( $disk )->download( $path, basename( $path ) );
+	}
+}

--- a/src/Http/Controllers/DataRequestVerificationController.php
+++ b/src/Http/Controllers/DataRequestVerificationController.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * DataRequestVerificationController — handles the user-facing identity
+ * verification flow for data subject requests.
+ *
+ * `show` renders the verification view bundled with the package; `verify`
+ * confirms the token and transitions the underlying request from
+ * `pending` → `processing`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Http\Controllers;
+
+use ArtisanPackUI\Privacy\Services\VerificationService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\View\View;
+
+/**
+ * Verification controller.
+ *
+ * @since 1.0.0
+ */
+class DataRequestVerificationController extends Controller
+{
+	public function __construct( protected VerificationService $verifier )
+	{
+	}
+
+	/**
+	 * Renders the verification page so the user can confirm their request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $token Token from the verification link.
+	 *
+	 * @return View
+	 */
+	public function show( string $token ): View
+	{
+		$request = $this->verifier->findByToken( $token );
+
+		abort_if( null === $request, 404, 'Verification link is invalid.' );
+
+		return view( 'privacy::verification.show', [
+			'dataRequest' => $request,
+			'token'       => $token,
+			'expired'     => $this->verifier->isExpired( $request ),
+		] );
+	}
+
+	/**
+	 * Confirms the token and transitions the request to processing.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request HTTP request (unused but kept for middleware DI).
+	 * @param  string   $token   Token from the URL.
+	 *
+	 * @return RedirectResponse
+	 */
+	public function verify( Request $request, string $token ): RedirectResponse
+	{
+		$dataRequest = $this->verifier->findByToken( $token );
+
+		abort_if( null === $dataRequest, 404, 'Verification link is invalid.' );
+
+		if ( $this->verifier->isExpired( $dataRequest ) ) {
+			return redirect()
+				->route( 'privacy.verification.show', [ 'token' => $token ] )
+				->withErrors( [ 'token' => __( 'This verification link has expired. Please submit a new request.' ) ] );
+		}
+
+		$confirmed = $this->verifier->confirm( $dataRequest, config( 'artisanpack.privacy.data_requests.verification_method', 'email' ) );
+
+		return redirect()
+			->route( 'privacy.verification.show', [ 'token' => $token ] )
+			->with( 'status', $confirmed
+				? __( 'Your identity has been verified and your request is now being processed.' )
+				: __( 'This request has already been verified or is no longer pending.' ),
+			);
+	}
+}

--- a/src/Listeners/NotifyAdminOfRequest.php
+++ b/src/Listeners/NotifyAdminOfRequest.php
@@ -20,8 +20,9 @@ use ArtisanPackUI\Privacy\Events\DataDeletionRequested;
 use ArtisanPackUI\Privacy\Events\DataExportRequested;
 use ArtisanPackUI\Privacy\Events\DataRectificationRequested;
 use ArtisanPackUI\Privacy\Models\DataRequest;
+use ArtisanPackUI\Privacy\Notifications\AdminDataRequestNotification;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
 
 /**
  * Sends a plain-text notification to `artisanpack.privacy.data_requests.admin_email`
@@ -116,20 +117,7 @@ class NotifyAdminOfRequest
 			return;
 		}
 
-		$body = sprintf(
-			"A new %s request has been filed.\n\nRequest ID: %s\nSubject: %s #%s\nRegulation: %s\nDue: %s",
-			$request->type,
-			(string) $request->getKey(),
-			(string) $request->requestable_type,
-			(string) $request->requestable_id,
-			(string) ( $request->regulation ?? 'n/a' ),
-			null !== $request->due_at ? $request->due_at->toIso8601String() : 'n/a',
-		);
-
-		Mail::raw( $body, function ( $message ) use ( $adminEmail, $request ): void {
-			$message
-				->to( $adminEmail )
-				->subject( sprintf( '[Privacy] New %s request #%s', $request->type, (string) $request->getKey() ) );
-		} );
+		Notification::route( 'mail', $adminEmail )
+			->notify( new AdminDataRequestNotification( $request ) );
 	}
 }

--- a/src/Listeners/ProcessDataAccessRequest.php
+++ b/src/Listeners/ProcessDataAccessRequest.php
@@ -51,6 +51,10 @@ class ProcessDataAccessRequest
 			return;
 		}
 
+		if ( true === (bool) config( 'artisanpack.privacy.data_requests.require_verification', true ) && null === $request->verified_at ) {
+			return;
+		}
+
 		$request->update( [ 'status' => DataRequest::STATUS_PROCESSING ] );
 
 		DataRequestLog::query()->create( [

--- a/src/Listeners/ProcessDataExportRequest.php
+++ b/src/Listeners/ProcessDataExportRequest.php
@@ -51,6 +51,10 @@ class ProcessDataExportRequest
 			return;
 		}
 
+		if ( true === (bool) config( 'artisanpack.privacy.data_requests.require_verification', true ) && null === $request->verified_at ) {
+			return;
+		}
+
 		$request->update( [ 'status' => DataRequest::STATUS_PROCESSING ] );
 
 		DataRequestLog::query()->create( [

--- a/src/Livewire/VerifyDataRequest.php
+++ b/src/Livewire/VerifyDataRequest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * VerifyDataRequest Livewire component — confirms a data subject request's
+ * identity verification token.
+ *
+ * Embeddable on the host application's verification page. Renders the
+ * current verification state, lets the subject confirm, and transitions
+ * the underlying {@see \ArtisanPackUI\Privacy\Models\DataRequest} from
+ * `pending` → `processing` via {@see VerificationService}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Livewire;
+
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use ArtisanPackUI\Privacy\Services\VerificationService;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+/**
+ * Livewire verification component.
+ *
+ * @since 1.0.0
+ */
+class VerifyDataRequest extends Component
+{
+	#[Locked]
+	public string $token = '';
+
+	public ?DataRequest $dataRequest = null;
+
+	public bool $expired = false;
+
+	public bool $confirmed = false;
+
+	public ?string $message = null;
+
+	/**
+	 * Resolve the token's request when the component mounts.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string             $token  Verification token.
+	 * @param  VerificationService $verifier Injected service.
+	 *
+	 * @return void
+	 */
+	public function mount( string $token, VerificationService $verifier ): void
+	{
+		$this->token       = $token;
+		$this->dataRequest = $verifier->findByToken( $token );
+
+		if ( null !== $this->dataRequest ) {
+			$this->expired   = $verifier->isExpired( $this->dataRequest );
+			$this->confirmed = null !== $this->dataRequest->verified_at;
+		}
+	}
+
+	/**
+	 * Confirm the request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  VerificationService  $verifier Injected service.
+	 *
+	 * @return void
+	 */
+	public function confirm( VerificationService $verifier ): void
+	{
+		if ( null === $this->dataRequest ) {
+			$this->message = __( 'Verification link is invalid.' );
+			return;
+		}
+
+		if ( $verifier->confirm( $this->dataRequest, config( 'artisanpack.privacy.data_requests.verification_method', 'email' ) ) ) {
+			$this->confirmed = true;
+			$this->message   = __( 'Your identity has been verified and your request is now being processed.' );
+			$this->dataRequest->refresh();
+			return;
+		}
+
+		$this->message = __( 'This request has already been verified or is no longer pending.' );
+	}
+
+	/**
+	 * Render the component.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'privacy::livewire.verify-data-request' );
+	}
+}

--- a/src/Models/ScheduledDeletion.php
+++ b/src/Models/ScheduledDeletion.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * ScheduledDeletion model — represents a future or completed data deletion.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * Eloquent model for the `privacy_scheduled_deletions` table.
+ *
+ * @property int                              $id
+ * @property string                           $deletable_type
+ * @property int                              $deletable_id
+ * @property string                           $strategy
+ * @property \Illuminate\Support\Carbon       $scheduled_for
+ * @property \Illuminate\Support\Carbon|null  $processed_at
+ * @property \Illuminate\Support\Carbon|null  $cancelled_at
+ * @property string|null                      $cancelled_reason
+ * @property int|null                         $requested_by
+ * @property array|null                       $options
+ *
+ * @since 1.0.0
+ */
+class ScheduledDeletion extends Model
+{
+	protected $table = 'privacy_scheduled_deletions';
+
+	protected $fillable = [
+		'deletable_type',
+		'deletable_id',
+		'strategy',
+		'scheduled_for',
+		'processed_at',
+		'cancelled_at',
+		'cancelled_reason',
+		'requested_by',
+		'options',
+	];
+
+	public function deletable(): MorphTo
+	{
+		return $this->morphTo();
+	}
+
+	public function scopePending( Builder $query ): Builder
+	{
+		return $query->whereNull( 'processed_at' )->whereNull( 'cancelled_at' );
+	}
+
+	public function scopeDue( Builder $query ): Builder
+	{
+		return $query->pending()->where( 'scheduled_for', '<=', now() );
+	}
+
+	public function isPending(): bool
+	{
+		return null === $this->processed_at && null === $this->cancelled_at;
+	}
+
+	protected function casts(): array
+	{
+		return [
+			'scheduled_for' => 'datetime',
+			'processed_at'  => 'datetime',
+			'cancelled_at'  => 'datetime',
+			'options'       => 'array',
+		];
+	}
+}

--- a/src/Notifications/AdminDataRequestNotification.php
+++ b/src/Notifications/AdminDataRequestNotification.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * AdminDataRequestNotification — notifies the configured admin address of a
+ * new incoming data subject request.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+
+class AdminDataRequestNotification extends DataRequestNotification
+{
+	public function toMail( object $notifiable ): MailMessage
+	{
+		return ( new MailMessage() )
+			->subject( __( 'New data request received (:type)', [ 'type' => $this->request->type ] ) )
+			->line( __( 'A new :type request (#:id) was filed by :subject_type #:subject_id.', [
+				'type'         => $this->request->type,
+				'id'           => $this->request->id,
+				'subject_type' => class_basename( $this->request->requestable_type ),
+				'subject_id'   => $this->request->requestable_id,
+			] ) )
+			->line( __( 'Status: :status. Due: :due.', [
+				'status' => $this->request->status,
+				'due'    => optional( $this->request->due_at )->toDayDateTimeString() ?? '—',
+			] ) );
+	}
+
+	protected function notificationKey(): string
+	{
+		return 'admin';
+	}
+}

--- a/src/Notifications/DataRequestCompleted.php
+++ b/src/Notifications/DataRequestCompleted.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * DataRequestCompleted — delivers the final result (or download link) for
+ * a completed data subject request.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+
+class DataRequestCompleted extends DataRequestNotification
+{
+	public function __construct( public \ArtisanPackUI\Privacy\Models\DataRequest $request, public ?string $downloadUrl = null )
+	{
+		parent::__construct( $request );
+	}
+
+	public function toMail( object $notifiable ): MailMessage
+	{
+		$message = ( new MailMessage() )
+			->subject( __( 'Your data request is complete' ) )
+			->line( __( 'Your :type request (#:id) has been completed.', [
+				'type' => $this->request->type,
+				'id'   => $this->request->id,
+			] ) );
+
+		if ( null !== $this->downloadUrl ) {
+			$message->action( __( 'Download Your Data' ), $this->downloadUrl );
+			$message->line( __( 'This download link will expire shortly for your security.' ) );
+		}
+
+		return $message;
+	}
+
+	public function toArray( object $notifiable ): array
+	{
+		return array_merge( parent::toArray( $notifiable ), [
+			'download_url' => $this->downloadUrl,
+		] );
+	}
+
+	protected function notificationKey(): string
+	{
+		return 'completed';
+	}
+}

--- a/src/Notifications/DataRequestNotification.php
+++ b/src/Notifications/DataRequestNotification.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * DataRequestNotification — base class shared by the package's data-request
+ * notifications. Resolves the configured channel list and queue connection
+ * once so subclasses only need to override the mail/database payloads.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Notifications;
+
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Abstract base notification.
+ *
+ * @since 1.0.0
+ */
+abstract class DataRequestNotification extends Notification implements ShouldQueue
+{
+	use Queueable;
+
+	/**
+	 * @param DataRequest $request The data request the notification relates to.
+	 */
+	public function __construct( public DataRequest $request )
+	{
+		$this->onQueue( (string) config( 'artisanpack.privacy.notifications.queue', 'default' ) );
+	}
+
+	/**
+	 * Returns the configured channels for this notification key (`received`,
+	 * `verification`, etc.), falling back to the package-wide default.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function via( object $notifiable ): array
+	{
+		$default  = (array) config( 'artisanpack.privacy.notifications.channels', [ 'mail' ] );
+		$override = (array) config( 'artisanpack.privacy.notifications.' . $this->notificationKey() . '.channels', $default );
+
+		return [] === $override ? $default : $override;
+	}
+
+	/**
+	 * Default database payload — subclasses may override to add fields.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray( object $notifiable ): array
+	{
+		return [
+			'data_request_id' => $this->request->id,
+			'type'            => $this->request->type,
+			'status'          => $this->request->status,
+			'notification'    => $this->notificationKey(),
+		];
+	}
+
+	/**
+	 * Stable identifier used when looking up per-notification overrides in
+	 * the config (e.g. `notifications.verification.channels`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	abstract protected function notificationKey(): string;
+}

--- a/src/Notifications/DataRequestProcessing.php
+++ b/src/Notifications/DataRequestProcessing.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * DataRequestProcessing — notifies the subject that processing has started.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+
+class DataRequestProcessing extends DataRequestNotification
+{
+	public function toMail( object $notifiable ): MailMessage
+	{
+		return ( new MailMessage() )
+			->subject( __( 'Your data request is being processed' ) )
+			->line( __( 'We have started processing your :type request (#:id).', [
+				'type' => $this->request->type,
+				'id'   => $this->request->id,
+			] ) );
+	}
+
+	protected function notificationKey(): string
+	{
+		return 'processing';
+	}
+}

--- a/src/Notifications/DataRequestReceived.php
+++ b/src/Notifications/DataRequestReceived.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * DataRequestReceived — confirms to the data subject that their request
+ * was received successfully.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+
+class DataRequestReceived extends DataRequestNotification
+{
+	public function toMail( object $notifiable ): MailMessage
+	{
+		return ( new MailMessage() )
+			->subject( __( 'We received your data request' ) )
+			->line( __( 'Your :type request (#:id) has been received.', [
+				'type' => $this->request->type,
+				'id'   => $this->request->id,
+			] ) )
+			->line( __( 'We will get back to you within :days days as required by the applicable regulations.', [
+				'days' => optional( $this->request->due_at )->diffInDays( now() ) ?? config( 'artisanpack.privacy.data_requests.response_days.default', 30 ),
+			] ) );
+	}
+
+	protected function notificationKey(): string
+	{
+		return 'received';
+	}
+}

--- a/src/Notifications/DataRequestRejected.php
+++ b/src/Notifications/DataRequestRejected.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * DataRequestRejected — notifies the subject that their request was denied.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+
+class DataRequestRejected extends DataRequestNotification
+{
+	public function __construct( public \ArtisanPackUI\Privacy\Models\DataRequest $request, public ?string $reason = null )
+	{
+		parent::__construct( $request );
+	}
+
+	public function toMail( object $notifiable ): MailMessage
+	{
+		$message = ( new MailMessage() )
+			->subject( __( 'Your data request was not approved' ) )
+			->line( __( 'Your :type request (#:id) could not be approved at this time.', [
+				'type' => $this->request->type,
+				'id'   => $this->request->id,
+			] ) );
+
+		if ( null !== $this->reason && '' !== $this->reason ) {
+			$message->line( __( 'Reason: :reason', [ 'reason' => $this->reason ] ) );
+		}
+
+		return $message;
+	}
+
+	public function toArray( object $notifiable ): array
+	{
+		return array_merge( parent::toArray( $notifiable ), [
+			'reason' => $this->reason,
+		] );
+	}
+
+	protected function notificationKey(): string
+	{
+		return 'rejected';
+	}
+}

--- a/src/Notifications/DataRequestVerificationRequired.php
+++ b/src/Notifications/DataRequestVerificationRequired.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * DataRequestVerificationRequired — sends the subject the verification link.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Notifications;
+
+use ArtisanPackUI\Privacy\Services\VerificationService;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class DataRequestVerificationRequired extends DataRequestNotification
+{
+	public function toMail( object $notifiable ): MailMessage
+	{
+		$url = app( VerificationService::class )->verificationUrl( $this->request ) ?? '#';
+
+		return ( new MailMessage() )
+			->subject( __( 'Verify your data request' ) )
+			->line( __( 'Confirm that you submitted the :type request (#:id) by visiting the link below.', [
+				'type' => $this->request->type,
+				'id'   => $this->request->id,
+			] ) )
+			->action( __( 'Verify Request' ), $url )
+			->line( __( 'This link expires in :minutes minutes.', [
+				'minutes' => (int) config( 'artisanpack.privacy.verification.token_ttl_minutes', 60 ),
+			] ) );
+	}
+
+	public function toArray( object $notifiable ): array
+	{
+		return array_merge( parent::toArray( $notifiable ), [
+			'verification_url' => app( VerificationService::class )->verificationUrl( $this->request ),
+		] );
+	}
+
+	protected function notificationKey(): string
+	{
+		return 'verification';
+	}
+}

--- a/src/PrivacyServiceProvider.php
+++ b/src/PrivacyServiceProvider.php
@@ -37,15 +37,21 @@ use ArtisanPackUI\Privacy\Listeners\SyncConsentOnLogin;
 use ArtisanPackUI\Privacy\Livewire\ConsentPreferences;
 use ArtisanPackUI\Privacy\Livewire\CookieBanner;
 use ArtisanPackUI\Privacy\Livewire\DataRequestForm;
+use ArtisanPackUI\Privacy\Livewire\VerifyDataRequest;
 use ArtisanPackUI\Privacy\Services\AnonymizationService;
 use ArtisanPackUI\Privacy\Services\ConsentService;
+use ArtisanPackUI\Privacy\Services\DataDeletionService;
+use ArtisanPackUI\Privacy\Services\DataExportService;
 use ArtisanPackUI\Privacy\Services\DataRequestService;
+use ArtisanPackUI\Privacy\Services\VerificationService;
 use ArtisanPackUI\Privacy\View\PrivacyDirectives;
 use Illuminate\Auth\Events\Login;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -121,6 +127,18 @@ class PrivacyServiceProvider extends ServiceProvider
 
 		$this->app->singleton( AnonymizationService::class, fn () => new AnonymizationService() );
 		$this->app->alias( AnonymizationService::class, 'privacy.anonymization' );
+
+		$this->app->singleton( DataExportService::class, fn () => new DataExportService() );
+		$this->app->alias( DataExportService::class, 'privacy.export' );
+
+		$this->app->singleton(
+			DataDeletionService::class,
+			fn ( $app ) => new DataDeletionService( $app->make( AnonymizationService::class ) ),
+		);
+		$this->app->alias( DataDeletionService::class, 'privacy.deletion' );
+
+		$this->app->singleton( VerificationService::class, fn () => new VerificationService() );
+		$this->app->alias( VerificationService::class, 'privacy.verification' );
 	}
 
 	/**
@@ -151,11 +169,54 @@ class PrivacyServiceProvider extends ServiceProvider
 		$this->loadPackageViews();
 		$this->registerLivewireComponents();
 		$this->registerApiRoutes();
+		$this->registerWebRoutes();
 		$this->registerBladeDirectives();
 		$this->registerMiddlewareAliases();
+		$this->registerRateLimiters();
 		$this->registerViewComposers();
 		$this->registerConsoleCommands();
 		$this->registerScheduledTasks();
+	}
+
+	/**
+	 * Registers the package's web routes (verification + export downloads).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function registerWebRoutes(): void
+	{
+		if ( true !== (bool) config( 'artisanpack.privacy.routes.enabled', true ) ) {
+			return;
+		}
+
+		Route::group( [
+			'prefix'     => (string) config( 'artisanpack.privacy.routes.prefix', 'privacy' ),
+			'middleware' => (array) config( 'artisanpack.privacy.routes.middleware', [ 'web' ] ),
+		], function (): void {
+			$this->loadRoutesFrom( __DIR__ . '/../routes/web.php' );
+		} );
+	}
+
+	/**
+	 * Registers the named rate limiters used by the package's HTTP routes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function registerRateLimiters(): void
+	{
+		$rule               = (string) config( 'artisanpack.privacy.verification.rate_limit', '6,1' );
+		[ $hits, $minutes ] = array_pad( explode( ',', $rule ), 2, '1' );
+
+		RateLimiter::for( 'privacy-verification', static function ( $request ) use ( $hits, $minutes ) {
+			return Limit::perMinutes(
+				(int) $minutes,
+				(int) $hits,
+			)->by( $request->ip() ?: 'anon' );
+		} );
 	}
 
 	/**
@@ -373,5 +434,6 @@ class PrivacyServiceProvider extends ServiceProvider
 		\Livewire\Livewire::component( 'privacy-cookie-banner', CookieBanner::class );
 		\Livewire\Livewire::component( 'privacy-consent-preferences', ConsentPreferences::class );
 		\Livewire\Livewire::component( 'privacy-data-request-form', DataRequestForm::class );
+		\Livewire\Livewire::component( 'privacy-verify-data-request', VerifyDataRequest::class );
 	}
 }

--- a/src/Services/AnonymizationService.php
+++ b/src/Services/AnonymizationService.php
@@ -8,6 +8,9 @@
  * strategy (`artisanpack.privacy.anonymization.strategies.{type}`), and
  * writes the transformed value back to the model.
  *
+ * Supports explicit field lists, batch processing, audit logging, and
+ * reversible pseudonymization via Laravel's encrypter.
+ *
  * @package    ArtisanPack_UI
  * @subpackage Privacy
  *
@@ -20,7 +23,10 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Privacy\Services;
 
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Pure-PHP anonymization service.
@@ -36,13 +42,142 @@ class AnonymizationService
 	public const STRATEGY_GENERALIZE   = 'generalize';
 	public const STRATEGY_PSEUDONYMIZE = 'pseudonymize';
 
+	public const STRATEGY_REVERSIBLE_PSEUDONYMIZE = 'reversible_pseudonymize';
+
+	public const REVERSIBLE_PREFIX = 'rpsn:';
+
 	/**
-	 * Applies the configured strategies to every recognised personal-data
-	 * field on the model and persists the result.
+	 * Applies anonymization strategies to a model and persists the result.
 	 *
-	 * Returns true when at least one field was mutated and the model was
-	 * saved, false when nothing matched (so callers can warn about a no-op
-	 * anonymization).
+	 * When `$fields` is null the service uses pattern-based field discovery
+	 * via `artisanpack.privacy.discovery.field_patterns`. When `$fields` is
+	 * provided as `['column' => 'strategy', ...]` each column is anonymized
+	 * with the explicit strategy. As a shorthand, a numeric list of column
+	 * names will fall back to the column's configured strategy resolved by
+	 * the column's matched data-type.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model                            $model  Model to anonymize in place.
+	 * @param  array<int|string, string>|null   $fields Explicit field map, list of columns, or null for discovery.
+	 *
+	 * @return bool True when at least one column was mutated.
+	 */
+	public function anonymize( Model $model, ?array $fields = null ): bool
+	{
+		if ( null === $fields ) {
+			$mutated = $this->anonymizeByPatterns( $model );
+			$touched = $this->columnsTouchedByPatterns( $model );
+		} else {
+			$map     = $this->resolveFieldMap( $fields );
+			$mutated = $this->anonymizeFields( $model, $map );
+			$touched = array_keys( $map );
+		}
+
+		if ( $mutated ) {
+			$model->save();
+			$this->logAudit( $model, $touched );
+		}
+
+		return $mutated;
+	}
+
+	/**
+	 * Applies anonymization to every model in a collection or iterable.
+	 *
+	 * Returns the count of records that were actually mutated and saved;
+	 * records with no matching fields are skipped silently.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  iterable<int, Model>             $models  Models to anonymize.
+	 * @param  array<int|string, string>|null   $fields  Explicit field map or null for discovery.
+	 *
+	 * @return int Count of records anonymized and saved.
+	 */
+	public function anonymizeBatch( iterable $models, ?array $fields = null ): int
+	{
+		$count = 0;
+
+		foreach ( $models as $model ) {
+			if ( $this->anonymize( $model, $fields ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Applies a strategy to a single value (without touching a model).
+	 *
+	 * Alias kept for the AC contract from issue #19.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $value    Original value.
+	 * @param  string  $strategy Strategy key.
+	 * @param  string  $type     Optional data-type hint.
+	 *
+	 * @return string
+	 */
+	public function anonymizeField( string $value, string $strategy, string $type = '' ): string
+	{
+		return $this->applyStrategy( $value, $strategy, $type );
+	}
+
+	/**
+	 * Applies a single strategy to a single value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $value    Original value.
+	 * @param  string  $strategy Strategy key.
+	 * @param  string  $type     Data-type hint (used by generalize/truncate).
+	 *
+	 * @return string
+	 */
+	public function applyStrategy( string $value, string $strategy, string $type = '' ): string
+	{
+		return match ( $strategy ) {
+			self::STRATEGY_MASK                     => $this->mask( $value ),
+			self::STRATEGY_REDACT                   => '[REDACTED]',
+			self::STRATEGY_HASH                     => hash( $this->hashAlgorithm(), $value ),
+			self::STRATEGY_TRUNCATE                 => $this->truncate( $value, $type ),
+			self::STRATEGY_GENERALIZE               => $this->generalize( $value, $type ),
+			self::STRATEGY_PSEUDONYMIZE             => $this->pseudonymize( $value ),
+			self::STRATEGY_REVERSIBLE_PSEUDONYMIZE  => $this->reversiblePseudonymize( $value ),
+			default                                 => '[REDACTED]',
+		};
+	}
+
+	/**
+	 * Returns the original value for a reversible pseudonym, or null if the
+	 * value is not a recognized reversible pseudonym.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $value Pseudonymized value (must start with REVERSIBLE_PREFIX).
+	 *
+	 * @return string|null
+	 */
+	public function reverse( string $value ): ?string
+	{
+		if ( ! str_starts_with( $value, self::REVERSIBLE_PREFIX ) ) {
+			return null;
+		}
+
+		$payload = substr( $value, strlen( self::REVERSIBLE_PREFIX ) );
+
+		try {
+			return Crypt::decryptString( $payload );
+		} catch ( DecryptException ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Anonymizes a model using pattern-based discovery (legacy behaviour).
 	 *
 	 * @since 1.0.0
 	 *
@@ -50,7 +185,7 @@ class AnonymizationService
 	 *
 	 * @return bool
 	 */
-	public function anonymize( Model $model ): bool
+	protected function anonymizeByPatterns( Model $model ): bool
 	{
 		$strategies = (array) config( 'artisanpack.privacy.anonymization.strategies', [] );
 		$mutated    = false;
@@ -72,35 +207,111 @@ class AnonymizationService
 			$mutated = true;
 		}
 
-		if ( $mutated ) {
-			$model->save();
+		return $mutated;
+	}
+
+	/**
+	 * Returns the list of columns the pattern-driven path actually mutated
+	 * (used for audit logging).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $model Model that was just mutated.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function columnsTouchedByPatterns( Model $model ): array
+	{
+		return array_values( array_keys( $model->getDirty() ) );
+	}
+
+	/**
+	 * Applies the resolved column/strategy map to the model.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model                  $model Model to mutate.
+	 * @param  array<string, string>  $map   Column => strategy map.
+	 *
+	 * @return bool
+	 */
+	protected function anonymizeFields( Model $model, array $map ): bool
+	{
+		$mutated = false;
+
+		foreach ( $map as $column => $strategy ) {
+			$value = $model->getAttribute( $column );
+
+			if ( null === $value || '' === $value ) {
+				continue;
+			}
+
+			$type = $this->guessTypeForColumn( $column );
+
+			$model->setAttribute( $column, $this->applyStrategy( (string) $value, $strategy, $type ) );
+			$mutated = true;
 		}
 
 		return $mutated;
 	}
 
 	/**
-	 * Applies a single strategy to a single value.
+	 * Normalises the `$fields` argument into a `column => strategy` map.
+	 *
+	 * Numeric entries are resolved against the configured per-type strategy
+	 * via the discovery patterns; associative entries are passed through.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  string  $value    Original value.
-	 * @param  string  $strategy Strategy key.
-	 * @param  string  $type     Data-type hint (used by generalize/truncate).
+	 * @param  array<int|string, string>  $fields Field argument from caller.
+	 *
+	 * @return array<string, string>
+	 */
+	protected function resolveFieldMap( array $fields ): array
+	{
+		$map = [];
+
+		foreach ( $fields as $key => $value ) {
+			if ( is_int( $key ) ) {
+				$column   = (string) $value;
+				$type     = $this->guessTypeForColumn( $column );
+				$strategy = (string) config(
+					"artisanpack.privacy.anonymization.strategies.{$type}",
+					self::STRATEGY_REDACT,
+				);
+
+				$map[ $column ] = $strategy;
+				continue;
+			}
+
+			$map[ (string) $key ] = (string) $value;
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Reverse-resolves a column name to a configured data-type key via the
+	 * discovery patterns. Falls back to the column name itself when no
+	 * pattern matches.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $column Column name.
 	 *
 	 * @return string
 	 */
-	public function applyStrategy( string $value, string $strategy, string $type = '' ): string
+	protected function guessTypeForColumn( string $column ): string
 	{
-		return match ( $strategy ) {
-			self::STRATEGY_MASK         => $this->mask( $value ),
-			self::STRATEGY_REDACT       => '[REDACTED]',
-			self::STRATEGY_HASH         => hash( $this->hashAlgorithm(), $value ),
-			self::STRATEGY_TRUNCATE     => $this->truncate( $value, $type ),
-			self::STRATEGY_GENERALIZE   => $this->generalize( $value, $type ),
-			self::STRATEGY_PSEUDONYMIZE => $this->pseudonymize( $value ),
-			default                     => '[REDACTED]',
-		};
+		$patterns = (array) config( 'artisanpack.privacy.discovery.field_patterns', [] );
+
+		foreach ( $patterns as $type => $columns ) {
+			if ( in_array( $column, (array) $columns, true ) ) {
+				return (string) $type;
+			}
+		}
+
+		return $column;
 	}
 
 	/**
@@ -212,6 +423,21 @@ class AnonymizationService
 	}
 
 	/**
+	 * Produces a reversible pseudonym using Laravel's encrypter. The original
+	 * value can be recovered via {@see reverse()}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $value Original value.
+	 *
+	 * @return string
+	 */
+	protected function reversiblePseudonymize( string $value ): string
+	{
+		return self::REVERSIBLE_PREFIX . Crypt::encryptString( $value );
+	}
+
+	/**
 	 * Finds the first column on the model that matches one of the
 	 * configured patterns for the given data type.
 	 *
@@ -246,5 +472,31 @@ class AnonymizationService
 	protected function hashAlgorithm(): string
 	{
 		return (string) config( 'artisanpack.privacy.anonymization.hash_algorithm', 'sha256' );
+	}
+
+	/**
+	 * Emits an audit-log entry describing which model/columns were anonymized.
+	 *
+	 * Records column names only — never the original or transformed values —
+	 * so audit logs remain safe to persist under regulatory retention rules.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model               $model    Model that was mutated.
+	 * @param  array<int, string>  $columns  Columns that were touched.
+	 *
+	 * @return void
+	 */
+	protected function logAudit( Model $model, array $columns ): void
+	{
+		if ( true !== (bool) config( 'artisanpack.privacy.anonymization.audit', true ) ) {
+			return;
+		}
+
+		Log::info( 'privacy.anonymization', [
+			'model'   => $model::class,
+			'key'     => $model->getKey(),
+			'columns' => $columns,
+		] );
 	}
 }

--- a/src/Services/DataDeletionService.php
+++ b/src/Services/DataDeletionService.php
@@ -1,0 +1,322 @@
+<?php
+
+/**
+ * DataDeletionService — applies configurable deletion strategies to data subjects.
+ *
+ * Supports hard delete, anonymize, and pseudonymize strategies plus a grace
+ * period (the subject's deletion is scheduled and can be cancelled until
+ * its `scheduled_for` timestamp passes). Cascade deletion follows the
+ * relations declared by the model's {@see HasPersonalData} trait.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Services;
+
+use ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+use ArtisanPackUI\Privacy\Events\DataSubjectDeleted;
+use ArtisanPackUI\Privacy\Events\DataSubjectDeletionScheduled;
+use ArtisanPackUI\Privacy\Models\ScheduledDeletion;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use InvalidArgumentException;
+
+/**
+ * Data subject deletion / anonymization / pseudonymization service.
+ *
+ * @since 1.0.0
+ */
+class DataDeletionService
+{
+	public const STRATEGY_DELETE       = 'delete';
+	public const STRATEGY_ANONYMIZE    = 'anonymize';
+	public const STRATEGY_PSEUDONYMIZE = 'pseudonymize';
+
+	/**
+	 * @param AnonymizationService $anonymizer Used for the anonymize/pseudonymize strategies.
+	 */
+	public function __construct( protected AnonymizationService $anonymizer )
+	{
+	}
+
+	/**
+	 * Applies the configured (or supplied) strategy to a subject.
+	 *
+	 * Recognised options:
+	 *  - `strategy`       (string) Override the default strategy.
+	 *  - `cascade`        (bool)   Override `artisanpack.privacy.deletion.cascade`.
+	 *  - `relations`      (array)  Explicit relation list (overrides trait).
+	 *  - `preserve_audit` (bool)   When true, audit-log rows are not pruned.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model                $subject Subject to act upon.
+	 * @param  array<string, mixed> $options Override flags.
+	 *
+	 * @throws InvalidArgumentException When the strategy is unknown.
+	 *
+	 * @return bool True when the strategy applied successfully.
+	 */
+	public function delete( Model $subject, array $options = [] ): bool
+	{
+		$strategy = (string) ( $options['strategy'] ?? config( 'artisanpack.privacy.deletion.default_strategy', self::STRATEGY_ANONYMIZE ) );
+		$cascade  = (bool) ( $options['cascade'] ?? config( 'artisanpack.privacy.deletion.cascade', true ) );
+
+		$result = match ( $strategy ) {
+			self::STRATEGY_DELETE       => $this->hardDelete( $subject ),
+			self::STRATEGY_ANONYMIZE    => $this->anonymize( $subject ),
+			self::STRATEGY_PSEUDONYMIZE => $this->pseudonymize( $subject ),
+			default                     => throw new InvalidArgumentException( "Unknown deletion strategy: {$strategy}" ),
+		};
+
+		if ( $result && $cascade ) {
+			$this->cascadeRelations( $subject, $strategy, $options['relations'] ?? null );
+		}
+
+		if ( $result ) {
+			Event::dispatch( new DataSubjectDeleted( $subject, $strategy ) );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Anonymizes the subject in place.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Subject to anonymize.
+	 *
+	 * @return bool True when at least one field was mutated.
+	 */
+	public function anonymize( Model $subject ): bool
+	{
+		return $this->anonymizer->anonymize( $subject );
+	}
+
+	/**
+	 * Pseudonymizes the subject's discoverable fields with the deterministic
+	 * (non-reversible) hash strategy so distinct subjects remain distinguishable
+	 * in audit logs without exposing the original values.
+	 *
+	 * For reversible pseudonymization (recoverable via the configured
+	 * encryption key), call {@see AnonymizationService::anonymize()} directly
+	 * with `STRATEGY_REVERSIBLE_PSEUDONYMIZE`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Subject to pseudonymize.
+	 *
+	 * @return bool
+	 */
+	public function pseudonymize( Model $subject ): bool
+	{
+		$strategies = (array) config( 'artisanpack.privacy.anonymization.strategies', [] );
+		$map        = [];
+
+		foreach ( array_keys( $strategies ) as $type ) {
+			$patterns = (array) config( "artisanpack.privacy.discovery.field_patterns.{$type}", [ $type ] );
+
+			foreach ( $patterns as $column ) {
+				if ( array_key_exists( $column, $subject->getAttributes() ) ) {
+					$map[ $column ] = AnonymizationService::STRATEGY_PSEUDONYMIZE;
+					break;
+				}
+			}
+		}
+
+		return [] !== $map && $this->anonymizer->anonymize( $subject, $map );
+	}
+
+	/**
+	 * Cascades a strategy to declared related models.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model                       $subject  Parent subject.
+	 * @param  array<int, string>          $relations Relation names to cascade across.
+	 *
+	 * @return int Count of related records mutated.
+	 */
+	public function deleteRelated( Model $subject, array $relations ): int
+	{
+		$strategy = (string) config( 'artisanpack.privacy.deletion.default_strategy', self::STRATEGY_ANONYMIZE );
+
+		return $this->cascadeRelations( $subject, $strategy, $relations );
+	}
+
+	/**
+	 * Schedules a deletion for the configured (or supplied) grace period.
+	 *
+	 * Returns the resulting {@see ScheduledDeletion} row so callers can
+	 * present the user with a "you can cancel until X" affordance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model                $subject Subject to schedule.
+	 * @param  int|null             $gracePeriodDays Override the configured grace period (days).
+	 * @param  array<string, mixed> $options Free-form options stored on the row.
+	 *
+	 * @return ScheduledDeletion
+	 */
+	public function scheduleForDeletion( Model $subject, ?int $gracePeriodDays = null, array $options = [] ): ScheduledDeletion
+	{
+		$days = $gracePeriodDays ?? (int) config( 'artisanpack.privacy.deletion.grace_period_days', 30 );
+
+		$scheduled = ScheduledDeletion::query()->create( [
+			'deletable_type'   => $subject->getMorphClass(),
+			'deletable_id'     => $subject->getKey(),
+			'strategy'         => (string) ( $options['strategy'] ?? config( 'artisanpack.privacy.deletion.default_strategy', self::STRATEGY_ANONYMIZE ) ),
+			'scheduled_for'    => Carbon::now()->addDays( $days ),
+			'requested_by'     => $options['requested_by'] ?? null,
+			'options'          => $options,
+		] );
+
+		Event::dispatch( new DataSubjectDeletionScheduled( $scheduled ) );
+
+		return $scheduled;
+	}
+
+	/**
+	 * Cancels the most recent pending scheduled deletion for the subject.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model        $subject Subject whose scheduled deletion is being cancelled.
+	 * @param  string|null  $reason  Optional cancellation reason.
+	 *
+	 * @return bool True when a pending row was cancelled.
+	 */
+	public function cancelScheduledDeletion( Model $subject, ?string $reason = null ): bool
+	{
+		$pending = ScheduledDeletion::query()
+			->where( 'deletable_type', $subject->getMorphClass() )
+			->where( 'deletable_id', $subject->getKey() )
+			->pending()
+			->latest( 'id' )
+			->first();
+
+		if ( null === $pending ) {
+			return false;
+		}
+
+		$pending->update( [
+			'cancelled_at'     => Carbon::now(),
+			'cancelled_reason' => $reason,
+		] );
+
+		return true;
+	}
+
+	/**
+	 * Processes a due scheduled deletion and applies its strategy.
+	 *
+	 * Called by the scheduler/queue worker once the grace period has passed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScheduledDeletion  $row Row to process.
+	 *
+	 * @return bool
+	 */
+	public function processScheduled( ScheduledDeletion $row ): bool
+	{
+		if ( ! $row->isPending() ) {
+			return false;
+		}
+
+		$subject = $row->deletable;
+
+		if ( ! $subject instanceof Model ) {
+			$row->update( [ 'processed_at' => Carbon::now() ] );
+			return false;
+		}
+
+		$result = $this->delete( $subject, array_merge(
+			(array) $row->options,
+			[ 'strategy' => $row->strategy ],
+		) );
+
+		$row->update( [ 'processed_at' => Carbon::now() ] );
+
+		return $result;
+	}
+
+	/**
+	 * Hard-deletes the subject inside a transaction so cascade work is
+	 * atomic with the delete call.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Subject to delete.
+	 *
+	 * @return bool
+	 */
+	protected function hardDelete( Model $subject ): bool
+	{
+		return (bool) DB::transaction( static fn (): bool => (bool) $subject->delete() );
+	}
+
+	/**
+	 * Cascades the strategy across the supplied (or trait-declared) relations.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model                     $subject   Parent subject.
+	 * @param  string                    $strategy  Strategy to apply to related models.
+	 * @param  array<int, string>|null   $relations Explicit relation list (overrides the trait).
+	 *
+	 * @return int
+	 */
+	protected function cascadeRelations( Model $subject, string $strategy, ?array $relations = null ): int
+	{
+		$relations ??= $this->usesPersonalData( $subject ) ? $subject->personalDataRelations() : [];
+		$count       = 0;
+
+		foreach ( (array) $relations as $relation ) {
+			if ( ! method_exists( $subject, $relation ) ) {
+				continue;
+			}
+
+			$query = $subject->{$relation}();
+
+			if ( ! $query instanceof Relation ) {
+				continue;
+			}
+
+			foreach ( $query->get() as $related ) {
+				self::STRATEGY_DELETE === $strategy
+					? $this->hardDelete( $related )
+					: $this->delete( $related, [ 'strategy' => $strategy, 'cascade' => false ] );
+
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Returns true when the subject uses the {@see HasPersonalData} trait.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Subject to inspect.
+	 *
+	 * @return bool
+	 */
+	protected function usesPersonalData( Model $subject ): bool
+	{
+		return in_array( HasPersonalData::class, class_uses_recursive( $subject ), true );
+	}
+}

--- a/src/Services/DataExportService.php
+++ b/src/Services/DataExportService.php
@@ -1,0 +1,454 @@
+<?php
+
+/**
+ * DataExportService — produces portable copies of a data subject's personal data.
+ *
+ * Collects column-level personal data from models tagged with the
+ * {@see HasPersonalData} trait, the subject's consent history, and its
+ * data-request activity log, then serializes the result to JSON, CSV, or
+ * XML for delivery to the subject.
+ *
+ * Other packages can append sections to the payload by listening for the
+ * {@see DataExportCollecting} event, or — when the `artisanpack-ui/hooks`
+ * package is installed — by registering an `addFilter('privacy.export.data', …)`
+ * filter that receives `($data, $subject)` and returns the mutated array.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Services;
+
+use ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+use ArtisanPackUI\Privacy\Events\DataExportCollecting;
+use ArtisanPackUI\Privacy\Models\Consent;
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use ArtisanPackUI\Privacy\Models\DataRequestLog;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use SimpleXMLElement;
+
+/**
+ * Data subject export service.
+ *
+ * @since 1.0.0
+ */
+class DataExportService
+{
+	public const FORMAT_JSON = 'json';
+	public const FORMAT_CSV  = 'csv';
+	public const FORMAT_XML  = 'xml';
+
+	/**
+	 * Returns the serialized export string for the supplied subject.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model   $subject Data subject the export belongs to.
+	 * @param  string  $format  One of FORMAT_JSON, FORMAT_CSV, FORMAT_XML.
+	 *
+	 * @throws InvalidArgumentException When the format is unsupported.
+	 *
+	 * @return string
+	 */
+	public function export( Model $subject, string $format = self::FORMAT_JSON ): string
+	{
+		$data = $this->collect( $subject );
+
+		return $this->serialize( $data, $format );
+	}
+
+	/**
+	 * Writes the export to the configured disk and returns a signed
+	 * download URL valid for `artisanpack.privacy.export.url_ttl` minutes.
+	 *
+	 * The stored file expires automatically — its `expires_at` is recorded
+	 * in a sidecar `<file>.expires` marker so the cleanup command can prune
+	 * stale exports without depending on a queue job.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model   $subject Data subject the export belongs to.
+	 * @param  string  $format  Export format.
+	 *
+	 * @return array{path: string, url: string, expires_at: string}
+	 */
+	public function exportToFile( Model $subject, string $format = self::FORMAT_JSON ): array
+	{
+		$payload   = $this->export( $subject, $format );
+		$disk      = $this->disk();
+		$ttl       = (int) config( 'artisanpack.privacy.export.url_ttl', 60 );
+		$retention = (int) config( 'artisanpack.privacy.export.file_retention_minutes', 1440 );
+
+		$filename = sprintf(
+			'%s/%s-%s.%s',
+			$this->directory(),
+			Str::slug( class_basename( $subject ) . '-' . $subject->getKey() ),
+			Str::lower( Str::random( 8 ) ),
+			$format,
+		);
+
+		Storage::disk( $disk )->put( $filename, $payload );
+
+		$expiresAt = Carbon::now()->addMinutes( $retention );
+		Storage::disk( $disk )->put( $filename . '.expires', $expiresAt->toIso8601String() );
+
+		return [
+			'path'       => $filename,
+			'url'        => URL::temporarySignedRoute(
+				'privacy.exports.download',
+				Carbon::now()->addMinutes( $ttl ),
+				[ 'path' => $filename ],
+			),
+			'expires_at' => $expiresAt->toIso8601String(),
+		];
+	}
+
+	/**
+	 * Collects the personal-data payload for a subject — column data from
+	 * `HasPersonalData` models, consent history, activity log, plus any
+	 * extensions contributed via event listeners or hooks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Data subject the export belongs to.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function getPersonalData( Model $subject ): array
+	{
+		return $this->collect( $subject );
+	}
+
+	/**
+	 * Returns the subject's consent history (grants and withdrawals) as a
+	 * plain array.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Data subject.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getConsentHistory( Model $subject ): array
+	{
+		return Consent::query()
+			->where( 'consentable_type', $subject->getMorphClass() )
+			->where( 'consentable_id', $subject->getKey() )
+			->orderBy( 'created_at' )
+			->limit( $this->rowCap() )
+			->get()
+			->map( static fn ( Consent $c ): array => [
+				'category'     => $c->category,
+				'granted'      => (bool) $c->granted,
+				'regulation'   => $c->regulation ?? null,
+				'recorded_at'  => $c->created_at?->toIso8601String(),
+				'withdrawn_at' => $c->withdrawn_at?->toIso8601String(),
+				'expires_at'   => $c->expires_at?->toIso8601String(),
+			] )
+			->all();
+	}
+
+	/**
+	 * Returns the subject's data-request activity log entries.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Data subject.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getActivityLog( Model $subject ): array
+	{
+		$requestIds = DataRequest::query()
+			->where( 'requestable_type', $subject->getMorphClass() )
+			->where( 'requestable_id', $subject->getKey() )
+			->pluck( 'id' );
+
+		if ( $requestIds->isEmpty() ) {
+			return [];
+		}
+
+		return DataRequestLog::query()
+			->whereIn( 'data_request_id', $requestIds )
+			->orderBy( 'created_at' )
+			->limit( $this->rowCap() )
+			->get()
+			->map( static fn ( DataRequestLog $log ): array => [
+				'data_request_id' => $log->data_request_id,
+				'action'          => $log->action,
+				'description'     => $log->description,
+				'performed_by'    => $log->performed_by,
+				'created_at'      => $log->created_at?->toIso8601String(),
+			] )
+			->all();
+	}
+
+	/**
+	 * Returns the model-by-model personal data for any related models tagged
+	 * with {@see HasPersonalData} (via its `personalDataRelations()`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Data subject.
+	 *
+	 * @return array<string, array<int, array<string, mixed>>>
+	 */
+	public function getRelatedData( Model $subject ): array
+	{
+		if ( ! $this->usesPersonalData( $subject ) ) {
+			return [];
+		}
+
+		return $subject->toPersonalDataRelationArray();
+	}
+
+	/**
+	 * Assembles the canonical payload before format-specific serialization.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Data subject.
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function collect( Model $subject ): array
+	{
+		$data = [
+			'subject'         => [
+				'type' => $subject->getMorphClass(),
+				'id'   => $subject->getKey(),
+			],
+			'personal_data'   => $this->usesPersonalData( $subject ) ? $subject->toPersonalDataArray() : [],
+			'related'         => $this->getRelatedData( $subject ),
+			'consent_history' => $this->getConsentHistory( $subject ),
+			'data_requests'   => $this->getDataRequestSummary( $subject ),
+			'activity_log'    => $this->getActivityLog( $subject ),
+			'generated_at'    => Carbon::now()->toIso8601String(),
+		];
+
+		$event = new DataExportCollecting( $subject, $data );
+		Event::dispatch( $event );
+		$data = $event->data;
+
+		if ( function_exists( 'applyFilters' ) ) {
+			$data = (array) applyFilters( 'privacy.export.data', $data, $subject );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Returns true when the model uses the {@see HasPersonalData} trait.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Subject to inspect.
+	 *
+	 * @return bool
+	 */
+	protected function usesPersonalData( Model $subject ): bool
+	{
+		return in_array( HasPersonalData::class, class_uses_recursive( $subject ), true );
+	}
+
+	/**
+	 * Returns a flat list of the subject's data-requests for inclusion in
+	 * the export.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $subject Data subject.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	protected function getDataRequestSummary( Model $subject ): array
+	{
+		return DataRequest::query()
+			->where( 'requestable_type', $subject->getMorphClass() )
+			->where( 'requestable_id', $subject->getKey() )
+			->orderBy( 'created_at' )
+			->limit( $this->rowCap() )
+			->get()
+			->map( static fn ( DataRequest $r ): array => [
+				'id'           => $r->id,
+				'type'         => $r->type,
+				'status'       => $r->status,
+				'regulation'   => $r->regulation,
+				'created_at'   => $r->created_at?->toIso8601String(),
+				'completed_at' => $r->completed_at?->toIso8601String(),
+			] )
+			->all();
+	}
+
+	/**
+	 * Serializes the payload to the requested format.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data   Export payload.
+	 * @param  string                $format Format key.
+	 *
+	 * @throws InvalidArgumentException
+	 *
+	 * @return string
+	 */
+	protected function serialize( array $data, string $format ): string
+	{
+		return match ( $format ) {
+			self::FORMAT_JSON => (string) json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+			self::FORMAT_CSV  => $this->toCsv( $data ),
+			self::FORMAT_XML  => $this->toXml( $data ),
+			default           => throw new InvalidArgumentException( "Unsupported export format: {$format}" ),
+		};
+	}
+
+	/**
+	 * Flattens the payload into a CSV with `section,key,value` rows so that
+	 * nested arrays survive a row-based format.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data Export payload.
+	 *
+	 * @return string
+	 */
+	protected function toCsv( array $data ): string
+	{
+		$handle = fopen( 'php://temp', 'r+' );
+
+		fputcsv( $handle, [ 'section', 'key', 'value' ], ',', '"', '\\' );
+
+		foreach ( $this->flatten( $data ) as [ $section, $key, $value ] ) {
+			fputcsv( $handle, [ $section, $key, $value ], ',', '"', '\\' );
+		}
+
+		rewind( $handle );
+		$out = (string) stream_get_contents( $handle );
+		fclose( $handle );
+
+		return $out;
+	}
+
+	/**
+	 * Renders the payload as XML.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data Export payload.
+	 *
+	 * @return string
+	 */
+	protected function toXml( array $data ): string
+	{
+		$root = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8"?><export/>' );
+		$this->arrayToXml( $data, $root );
+
+		return (string) $root->asXML();
+	}
+
+	/**
+	 * Recursive XML node builder.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int|string, mixed>  $data   Branch payload.
+	 * @param  SimpleXMLElement          $parent Parent node.
+	 *
+	 * @return void
+	 */
+	protected function arrayToXml( array $data, SimpleXMLElement $parent ): void
+	{
+		foreach ( $data as $key => $value ) {
+			$tag = is_int( $key ) ? 'item' : preg_replace( '/[^A-Za-z0-9_\-]/', '_', (string) $key );
+			$tag = '' === $tag ? 'item' : $tag;
+
+			if ( is_array( $value ) ) {
+				$child = $parent->addChild( $tag );
+				$this->arrayToXml( $value, $child );
+				continue;
+			}
+
+			$parent->addChild( $tag, htmlspecialchars( (string) ( $value ?? '' ), ENT_XML1 ) );
+		}
+	}
+
+	/**
+	 * Flattens a nested payload to `[section, key, value]` rows.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int|string, mixed>  $data   Payload to flatten.
+	 * @param  string                    $prefix Section prefix carried from parent.
+	 *
+	 * @return array<int, array{0: string, 1: string, 2: string}>
+	 */
+	protected function flatten( array $data, string $prefix = '' ): array
+	{
+		$rows = [];
+
+		foreach ( $data as $key => $value ) {
+			$section = '' === $prefix ? (string) $key : $prefix;
+			$label   = '' === $prefix ? '' : (string) $key;
+
+			if ( is_array( $value ) ) {
+				$childPrefix = '' === $prefix ? (string) $key : "{$prefix}.{$key}";
+				$rows        = array_merge( $rows, $this->flatten( $value, $childPrefix ) );
+				continue;
+			}
+
+			$rows[] = [ $section, $label, (string) ( $value ?? '' ) ];
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Configured filesystem disk for export storage.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	protected function disk(): string
+	{
+		return (string) config( 'artisanpack.privacy.export.disk', 'local' );
+	}
+
+	/**
+	 * Configured directory inside the disk for export files.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	protected function directory(): string
+	{
+		return trim( (string) config( 'artisanpack.privacy.export.directory', 'privacy-exports' ), '/' );
+	}
+
+	/**
+	 * Maximum number of rows per collected section. A safety net against an
+	 * accidental OOM when a high-volume subject has hundreds of thousands of
+	 * consent/log entries. Override via `artisanpack.privacy.export.row_cap`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	protected function rowCap(): int
+	{
+		return (int) config( 'artisanpack.privacy.export.row_cap', 10000 );
+	}
+}

--- a/src/Services/VerificationService.php
+++ b/src/Services/VerificationService.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * VerificationService — issues, validates, and confirms identity-verification
+ * tokens for data subject requests.
+ *
+ * The token lives on the {@see DataRequest} row (`verification_token`) and
+ * is considered expired once the request's `created_at` is older than
+ * `artisanpack.privacy.verification.token_ttl_minutes`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Services;
+
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use ArtisanPackUI\Privacy\Models\DataRequestLog;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+
+/**
+ * Identity verification service.
+ *
+ * @since 1.0.0
+ */
+class VerificationService
+{
+	/**
+	 * Looks up a request by its verification token (regardless of state).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $token Token from the verification link.
+	 *
+	 * @return DataRequest|null
+	 */
+	public function findByToken( string $token ): ?DataRequest
+	{
+		if ( '' === $token ) {
+			return null;
+		}
+
+		return DataRequest::query()->where( 'verification_token', $token )->first();
+	}
+
+	/**
+	 * Marks the supplied request as verified (sets `verified_at` and moves
+	 * the request from `pending` → `processing`).
+	 *
+	 * Returns false when the request is already verified, expired, or no
+	 * longer in a state that accepts verification.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  DataRequest  $request Request to verify.
+	 * @param  string|null  $method  Channel that confirmed identity (`email`, `manual`, etc).
+	 * @param  int|null     $performedBy Optional admin user id for manual verification.
+	 *
+	 * @return bool
+	 */
+	public function confirm( DataRequest $request, ?string $method = null, ?int $performedBy = null ): bool
+	{
+		if ( null !== $request->verified_at ) {
+			return false;
+		}
+
+		if ( $this->isExpired( $request ) ) {
+			return false;
+		}
+
+		if ( DataRequest::STATUS_PENDING !== $request->status ) {
+			return false;
+		}
+
+		$request->update( [
+			'verified_at' => Carbon::now(),
+			'status'      => DataRequest::STATUS_PROCESSING,
+		] );
+
+		DataRequestLog::query()->create( [
+			'data_request_id' => $request->getKey(),
+			'action'          => 'verification.confirmed',
+			'description'     => __( 'Identity verified via :method.', [
+				'method' => $method ?? config( 'artisanpack.privacy.data_requests.verification_method', 'email' ),
+			] ),
+			'performed_by'    => $performedBy,
+		] );
+
+		return true;
+	}
+
+	/**
+	 * Convenience wrapper for admin-driven manual verification.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  DataRequest  $request Request to verify.
+	 * @param  int|Model    $admin   Admin user (or id) recording the verification.
+	 *
+	 * @return bool
+	 */
+	public function manuallyVerify( DataRequest $request, Model|int $admin ): bool
+	{
+		$adminId = $admin instanceof Model ? (int) $admin->getKey() : (int) $admin;
+
+		return $this->confirm( $request, 'manual', $adminId );
+	}
+
+	/**
+	 * Returns true when the request's token is past its TTL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  DataRequest  $request Request to evaluate.
+	 *
+	 * @return bool
+	 */
+	public function isExpired( DataRequest $request ): bool
+	{
+		$ttl = (int) config( 'artisanpack.privacy.verification.token_ttl_minutes', 60 );
+
+		if ( $ttl <= 0 ) {
+			return false;
+		}
+
+		$reference = $request->created_at ?? Carbon::now();
+
+		return $reference->copy()->addMinutes( $ttl )->isPast();
+	}
+
+	/**
+	 * Re-issues a fresh token on an existing request and returns it.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  DataRequest  $request Request to refresh.
+	 *
+	 * @return string
+	 */
+	public function refreshToken( DataRequest $request ): string
+	{
+		$token = Str::random( 40 );
+
+		$request->update( [
+			'verification_token' => $token,
+			'verified_at'        => null,
+		] );
+
+		return $token;
+	}
+
+	/**
+	 * Builds the user-facing verification URL for the supplied request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  DataRequest  $request Request whose link should be generated.
+	 *
+	 * @return string|null Null when no token is set.
+	 */
+	public function verificationUrl( DataRequest $request ): ?string
+	{
+		if ( null === $request->verification_token || '' === $request->verification_token ) {
+			return null;
+		}
+
+		return URL::route( 'privacy.verification.show', [ 'token' => $request->verification_token ] );
+	}
+}

--- a/tests/Feature/Http/Controllers/DataExportDownloadControllerTest.php
+++ b/tests/Feature/Http/Controllers/DataExportDownloadControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+
+beforeEach( function (): void {
+	Storage::fake( 'local' );
+	config()->set( 'artisanpack.privacy.export.disk', 'local' );
+	config()->set( 'artisanpack.privacy.export.directory', 'privacy-exports' );
+} );
+
+it( 'streams the export file for a valid signed URL', function (): void {
+	$path = 'privacy-exports/test-export.json';
+	Storage::disk( 'local' )->put( $path, '{"hello":"world"}' );
+
+	$url = URL::temporarySignedRoute(
+		'privacy.exports.download',
+		Carbon::now()->addMinutes( 5 ),
+		[ 'path' => $path ],
+	);
+
+	$response = $this->get( $url );
+
+	$response->assertOk();
+	expect( $response->streamedContent() )->toBe( '{"hello":"world"}' );
+} );
+
+it( 'rejects a tampered signature with 403', function (): void {
+	$path = 'privacy-exports/test-export.json';
+	Storage::disk( 'local' )->put( $path, 'payload' );
+
+	$response = $this->get( route( 'privacy.exports.download', [ 'path' => $path ] ) );
+
+	$response->assertForbidden();
+} );
+
+it( 'returns 410 when the sidecar expiry marker is in the past', function (): void {
+	$path = 'privacy-exports/expired-export.json';
+	Storage::disk( 'local' )->put( $path, 'expired' );
+	Storage::disk( 'local' )->put( $path . '.expires', Carbon::now()->subHour()->toIso8601String() );
+
+	$url = URL::temporarySignedRoute(
+		'privacy.exports.download',
+		Carbon::now()->addMinutes( 5 ),
+		[ 'path' => $path ],
+	);
+
+	$this->get( $url )->assertStatus( 410 );
+} );
+
+it( 'refuses paths outside the configured export directory', function (): void {
+	$path = '../app/config.php';
+
+	$url = URL::temporarySignedRoute(
+		'privacy.exports.download',
+		Carbon::now()->addMinutes( 5 ),
+		[ 'path' => $path ],
+	);
+
+	$this->get( $url )->assertForbidden();
+} );
+
+it( 'returns 404 when the file is missing', function (): void {
+	$path = 'privacy-exports/missing.json';
+
+	$url = URL::temporarySignedRoute(
+		'privacy.exports.download',
+		Carbon::now()->addMinutes( 5 ),
+		[ 'path' => $path ],
+	);
+
+	$this->get( $url )->assertNotFound();
+} );

--- a/tests/Feature/Http/Controllers/DataRequestVerificationControllerTest.php
+++ b/tests/Feature/Http/Controllers/DataRequestVerificationControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\Support\TestSubject;
+
+beforeEach( function (): void {
+	Schema::create( 'test_subjects', function ( Blueprint $table ): void {
+		$table->id();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'test_subjects' );
+} );
+
+function makeVerificationRequest( string $token = 'verify-tok-1', bool $verified = false ): DataRequest
+{
+	$subject = TestSubject::create();
+
+	$request = DataRequest::query()->create( [
+		'requestable_type'   => $subject->getMorphClass(),
+		'requestable_id'     => $subject->getKey(),
+		'type'               => DataRequest::TYPE_ACCESS,
+		'status'             => DataRequest::STATUS_PENDING,
+		'verification_token' => $token,
+	] );
+
+	if ( $verified ) {
+		$request->update( [ 'verified_at' => now() ] );
+	}
+
+	return $request;
+}
+
+it( 'renders the verification page for a valid token', function (): void {
+	$request = makeVerificationRequest( 'show-token-1' );
+
+	$response = $this->get( route( 'privacy.verification.show', [ 'token' => 'show-token-1' ] ) );
+
+	$response->assertOk();
+	$response->assertSee( 'Verify Your Data Request' );
+	$response->assertSee( '#' . $request->id );
+} );
+
+it( 'returns 404 for an unknown token', function (): void {
+	$this->get( route( 'privacy.verification.show', [ 'token' => 'no-such-token' ] ) )
+		->assertNotFound();
+} );
+
+it( 'flips the request to processing on POST', function (): void {
+	$request = makeVerificationRequest( 'post-token-1' );
+
+	$response = $this->post( route( 'privacy.verification.verify', [ 'token' => 'post-token-1' ] ) );
+
+	$response->assertRedirect();
+	$request->refresh();
+	expect( $request->verified_at )->not->toBeNull();
+	expect( $request->status )->toBe( DataRequest::STATUS_PROCESSING );
+} );
+
+it( 'redirects with an expired errors bag for a stale token', function (): void {
+	config()->set( 'artisanpack.privacy.verification.token_ttl_minutes', 1 );
+
+	$request = makeVerificationRequest( 'stale-token-1' );
+	$request->forceFill( [ 'created_at' => now()->subHours( 2 ) ] )->save();
+
+	$response = $this->post( route( 'privacy.verification.verify', [ 'token' => 'stale-token-1' ] ) );
+
+	$response->assertRedirect();
+	$response->assertSessionHasErrors( [ 'token' ] );
+	$request->refresh();
+	expect( $request->verified_at )->toBeNull();
+} );
+
+it( 'returns 404 when verifying an unknown token', function (): void {
+	$this->post( route( 'privacy.verification.verify', [ 'token' => 'unknown' ] ) )
+		->assertNotFound();
+} );

--- a/tests/Feature/Listeners/ListenerRegistrationTest.php
+++ b/tests/Feature/Listeners/ListenerRegistrationTest.php
@@ -12,10 +12,11 @@ use ArtisanPackUI\Privacy\Models\BreachNotification;
 use ArtisanPackUI\Privacy\Models\Consent;
 use ArtisanPackUI\Privacy\Models\DataRequest;
 use ArtisanPackUI\Privacy\Models\DataRequestLog;
+use ArtisanPackUI\Privacy\Notifications\AdminDataRequestNotification;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Schema;
 use Mockery as M;
 use Tests\Support\TestSubject;
@@ -58,6 +59,7 @@ it( 'logs an info entry when LogConsentActivity handles ConsentWithdrawn', funct
 it( 'marks an access request as processing when auto-process is enabled', function (): void {
 	config()->set( 'artisanpack.privacy.data_requests.auto_process.access', true );
 	config()->set( 'artisanpack.privacy.data_requests.notify_admin', false );
+	config()->set( 'artisanpack.privacy.data_requests.require_verification', false );
 
 	$request = DataRequest::factory()->create( [
 		'type'             => DataRequest::TYPE_ACCESS,
@@ -91,6 +93,7 @@ it( 'leaves an access request untouched when auto-process is disabled', function
 it( 'marks an export request as processing when auto-process is enabled', function (): void {
 	config()->set( 'artisanpack.privacy.data_requests.auto_process.export', true );
 	config()->set( 'artisanpack.privacy.data_requests.notify_admin', false );
+	config()->set( 'artisanpack.privacy.data_requests.require_verification', false );
 
 	$request = DataRequest::factory()->create( [
 		'type'             => DataRequest::TYPE_EXPORT,
@@ -109,7 +112,7 @@ it( 'emails the admin when notify_admin is enabled and an access request is disp
 	config()->set( 'artisanpack.privacy.data_requests.admin_email', 'admin@example.com' );
 	config()->set( 'artisanpack.privacy.data_requests.auto_process.access', false );
 
-	Mail::spy();
+	Notification::fake();
 
 	$request = DataRequest::factory()->create( [
 		'type'             => DataRequest::TYPE_ACCESS,
@@ -120,14 +123,14 @@ it( 'emails the admin when notify_admin is enabled and an access request is disp
 
 	DataAccessRequested::dispatch( $request->fresh() );
 
-	Mail::shouldHaveReceived( 'raw' )->once();
+	Notification::assertSentOnDemand( AdminDataRequestNotification::class );
 } );
 
 it( 'emails the admin for a deletion request when notify_admin is enabled', function (): void {
 	config()->set( 'artisanpack.privacy.data_requests.notify_admin', true );
 	config()->set( 'artisanpack.privacy.data_requests.admin_email', 'admin@example.com' );
 
-	Mail::spy();
+	Notification::fake();
 
 	$request = DataRequest::factory()->create( [
 		'type'             => DataRequest::TYPE_DELETION,
@@ -138,13 +141,13 @@ it( 'emails the admin for a deletion request when notify_admin is enabled', func
 
 	DataDeletionRequested::dispatch( $request->fresh() );
 
-	Mail::shouldHaveReceived( 'raw' )->once();
+	Notification::assertSentOnDemand( AdminDataRequestNotification::class );
 } );
 
 it( 'does not email the admin when notify_admin is disabled', function (): void {
 	config()->set( 'artisanpack.privacy.data_requests.notify_admin', false );
 
-	Mail::spy();
+	Notification::fake();
 
 	$request = DataRequest::factory()->create( [
 		'type'             => DataRequest::TYPE_DELETION,
@@ -155,13 +158,13 @@ it( 'does not email the admin when notify_admin is disabled', function (): void 
 
 	DataDeletionRequested::dispatch( $request->fresh() );
 
-	Mail::shouldNotHaveReceived( 'raw' );
+	Notification::assertNothingSent();
 } );
 
 it( 'starts the breach workflow when NotifyDataBreach handles a DataBreach', function (): void {
 	config()->set( 'artisanpack.privacy.data_requests.admin_email', 'admin@example.com' );
 
-	Mail::spy();
+	Illuminate\Support\Facades\Mail::spy();
 	Log::spy();
 
 	$breach = BreachNotification::factory()->create();
@@ -171,7 +174,7 @@ it( 'starts the breach workflow when NotifyDataBreach handles a DataBreach', fun
 	Log::shouldHaveReceived( 'critical' )
 		->with( 'privacy.data_breach.reported', M::on( fn ( array $context ): bool => $context['breach_id'] === $breach->id ) )
 		->once();
-	Mail::shouldHaveReceived( 'raw' )->once();
+	Illuminate\Support\Facades\Mail::shouldHaveReceived( 'raw' )->once();
 } );
 
 it( 'syncs cookie consents to the database on Login via SyncConsentOnLogin', function (): void {

--- a/tests/Feature/Notifications/DataRequestNotificationsTest.php
+++ b/tests/Feature/Notifications/DataRequestNotificationsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use ArtisanPackUI\Privacy\Notifications\AdminDataRequestNotification;
+use ArtisanPackUI\Privacy\Notifications\DataRequestCompleted;
+use ArtisanPackUI\Privacy\Notifications\DataRequestReceived;
+use ArtisanPackUI\Privacy\Notifications\DataRequestRejected;
+use ArtisanPackUI\Privacy\Notifications\DataRequestVerificationRequired;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\Support\TestSubject;
+
+beforeEach( function (): void {
+	Schema::create( 'test_subjects', function ( Blueprint $table ): void {
+		$table->id();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'test_subjects' );
+} );
+
+function makeDataRequest(): DataRequest
+{
+	$subject = TestSubject::create();
+
+	return DataRequest::query()->create( [
+		'requestable_type'   => $subject->getMorphClass(),
+		'requestable_id'     => $subject->getKey(),
+		'type'               => DataRequest::TYPE_EXPORT,
+		'status'             => DataRequest::STATUS_PENDING,
+		'verification_token' => 'tok-notification',
+	] );
+}
+
+it( 'resolves channels via config including per-notification overrides', function (): void {
+	config()->set( 'artisanpack.privacy.notifications.channels', [ 'mail' ] );
+	config()->set( 'artisanpack.privacy.notifications.received.channels', [ 'mail', 'database' ] );
+
+	$notification = new DataRequestReceived( makeDataRequest() );
+
+	expect( $notification->via( new stdClass() ) )->toBe( [ 'mail', 'database' ] );
+} );
+
+it( 'builds a mail message for DataRequestReceived', function (): void {
+	$mail = ( new DataRequestReceived( makeDataRequest() ) )->toMail( new stdClass() );
+
+	expect( $mail->subject )->toContain( 'received your data request' );
+} );
+
+it( 'builds a verification mail with an action URL', function (): void {
+	$mail = ( new DataRequestVerificationRequired( makeDataRequest() ) )->toMail( new stdClass() );
+
+	expect( $mail->actionText )->toContain( 'Verify' );
+	expect( $mail->actionUrl )->toContain( 'tok-notification' );
+} );
+
+it( 'includes the download URL in DataRequestCompleted when provided', function (): void {
+	$notification = new DataRequestCompleted( makeDataRequest(), 'https://example.com/download' );
+	$mail         = $notification->toMail( new stdClass() );
+	$array        = $notification->toArray( new stdClass() );
+
+	expect( $mail->actionUrl )->toBe( 'https://example.com/download' );
+	expect( $array['download_url'] )->toBe( 'https://example.com/download' );
+} );
+
+it( 'includes the rejection reason in DataRequestRejected', function (): void {
+	$notification = new DataRequestRejected( makeDataRequest(), 'Insufficient identity proof' );
+	$array        = $notification->toArray( new stdClass() );
+
+	expect( $array['reason'] )->toBe( 'Insufficient identity proof' );
+} );
+
+it( 'builds an admin notification mail', function (): void {
+	$mail = ( new AdminDataRequestNotification( makeDataRequest() ) )->toMail( new stdClass() );
+
+	expect( $mail->subject )->toContain( 'New data request received' );
+} );

--- a/tests/Feature/Services/AnonymizationServiceTest.php
+++ b/tests/Feature/Services/AnonymizationServiceTest.php
@@ -77,6 +77,69 @@ it( 'anonymizes a model in place based on configured strategies', function (): v
 	expect( $subject->name )->toStartWith( 'Anon_' );
 } );
 
+it( 'anonymizes only the explicitly listed fields with an explicit strategy', function (): void {
+	$subject = AnonSubject::create( [
+		'email' => 'jacob@example.com',
+		'name'  => 'Jacob Martella',
+		'phone' => '555-1234',
+	] );
+
+	$mutated = app( AnonymizationService::class )->anonymize( $subject, [
+		'email' => AnonymizationService::STRATEGY_REDACT,
+	] );
+
+	expect( $mutated )->toBeTrue();
+	$subject->refresh();
+	expect( $subject->email )->toBe( '[REDACTED]' );
+	expect( $subject->name )->toBe( 'Jacob Martella' );
+	expect( $subject->phone )->toBe( '555-1234' );
+} );
+
+it( 'resolves a numeric field list to the configured per-type strategy', function (): void {
+	$subject = AnonSubject::create( [
+		'email' => 'jacob@example.com',
+		'phone' => '555-1234',
+	] );
+
+	app( AnonymizationService::class )->anonymize( $subject, [ 'email', 'phone' ] );
+
+	$subject->refresh();
+	expect( $subject->email )->toBe( 'j***@e***.com' );
+	expect( $subject->phone )->toBe( '[REDACTED]' );
+} );
+
+it( 'anonymizes a batch of models and returns the count mutated', function (): void {
+	$a = AnonSubject::create( [ 'email' => 'a@example.com' ] );
+	$b = AnonSubject::create( [ 'email' => 'b@example.com' ] );
+	$c = AnonSubject::create( [ 'email' => null ] );
+
+	$count = app( AnonymizationService::class )->anonymizeBatch( [ $a, $b, $c ] );
+
+	expect( $count )->toBe( 2 );
+} );
+
+it( 'reversibly pseudonymizes and recovers the original value', function (): void {
+	$service = app( AnonymizationService::class );
+	$token   = $service->applyStrategy( 'jacob@example.com', AnonymizationService::STRATEGY_REVERSIBLE_PSEUDONYMIZE );
+
+	expect( $token )->toStartWith( AnonymizationService::REVERSIBLE_PREFIX );
+	expect( $service->reverse( $token ) )->toBe( 'jacob@example.com' );
+} );
+
+it( 'returns null when reversing a value that is not a reversible pseudonym', function (): void {
+	$service = app( AnonymizationService::class );
+
+	expect( $service->reverse( 'plain string' ) )->toBeNull();
+	expect( $service->reverse( AnonymizationService::REVERSIBLE_PREFIX . 'not-a-real-token' ) )->toBeNull();
+} );
+
+it( 'exposes anonymizeField as an alias for applyStrategy', function (): void {
+	$service = app( AnonymizationService::class );
+
+	expect( $service->anonymizeField( 'jacob@example.com', AnonymizationService::STRATEGY_MASK, 'email' ) )
+		->toBe( $service->applyStrategy( 'jacob@example.com', AnonymizationService::STRATEGY_MASK, 'email' ) );
+} );
+
 it( 'returns false when no personal-data columns match', function (): void {
 	Schema::create( 'plain_subjects', function ( Blueprint $table ): void {
 		$table->id();

--- a/tests/Feature/Services/DataDeletionServiceTest.php
+++ b/tests/Feature/Services/DataDeletionServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+use ArtisanPackUI\Privacy\Events\DataSubjectDeleted;
+use ArtisanPackUI\Privacy\Events\DataSubjectDeletionScheduled;
+use ArtisanPackUI\Privacy\Models\ScheduledDeletion;
+use ArtisanPackUI\Privacy\Services\DataDeletionService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach( function (): void {
+	Schema::create( 'deletion_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'email' )->nullable();
+		$table->string( 'name' )->nullable();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'deletion_subjects' );
+} );
+
+class DeletionSubject extends Model
+{
+	use HasPersonalData;
+
+	public $timestamps = false;
+
+	protected $table = 'deletion_subjects';
+
+	protected $guarded = [];
+
+	protected array $personalDataFields = [ 'email', 'name' ];
+
+	public function getMorphClass(): string
+	{
+		return 'deletion_subject';
+	}
+}
+
+it( 'anonymizes a subject when the default strategy is anonymize', function (): void {
+	config()->set( 'artisanpack.privacy.deletion.default_strategy', DataDeletionService::STRATEGY_ANONYMIZE );
+
+	$subject = DeletionSubject::create( [ 'email' => 'jacob@example.com', 'name' => 'Jacob' ] );
+
+	Event::fake( [ DataSubjectDeleted::class ] );
+
+	$result = app( DataDeletionService::class )->delete( $subject );
+
+	expect( $result )->toBeTrue();
+	$subject->refresh();
+	expect( $subject->email )->toBe( 'j***@e***.com' );
+	Event::assertDispatched( DataSubjectDeleted::class );
+} );
+
+it( 'hard-deletes a subject when the strategy is delete', function (): void {
+	$subject = DeletionSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	app( DataDeletionService::class )->delete( $subject, [ 'strategy' => DataDeletionService::STRATEGY_DELETE ] );
+
+	expect( DeletionSubject::query()->find( $subject->id ) )->toBeNull();
+} );
+
+it( 'pseudonymizes a subject with the reversible strategy', function (): void {
+	$subject = DeletionSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	$result = app( DataDeletionService::class )->pseudonymize( $subject );
+
+	expect( $result )->toBeTrue();
+	$subject->refresh();
+	expect( $subject->email )->not->toBe( 'jacob@example.com' );
+	expect( $subject->email )->toStartWith( 'Anon_' );
+} );
+
+it( 'throws for an unknown strategy', function (): void {
+	$subject = DeletionSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	app( DataDeletionService::class )->delete( $subject, [ 'strategy' => 'shred' ] );
+} )->throws( InvalidArgumentException::class );
+
+it( 'schedules a deletion with the configured grace period', function (): void {
+	Event::fake( [ DataSubjectDeletionScheduled::class ] );
+
+	$subject = DeletionSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	$scheduled = app( DataDeletionService::class )->scheduleForDeletion( $subject, 7 );
+
+	expect( $scheduled )->toBeInstanceOf( ScheduledDeletion::class );
+	expect( $scheduled->isPending() )->toBeTrue();
+	expect( $scheduled->scheduled_for->isFuture() )->toBeTrue();
+	Event::assertDispatched( DataSubjectDeletionScheduled::class );
+} );
+
+it( 'cancels a pending scheduled deletion', function (): void {
+	$subject   = DeletionSubject::create( [ 'email' => 'jacob@example.com' ] );
+	$scheduled = app( DataDeletionService::class )->scheduleForDeletion( $subject, 7 );
+
+	$cancelled = app( DataDeletionService::class )->cancelScheduledDeletion( $subject, 'user changed their mind' );
+
+	expect( $cancelled )->toBeTrue();
+	$scheduled->refresh();
+	expect( $scheduled->cancelled_at )->not->toBeNull();
+	expect( $scheduled->cancelled_reason )->toBe( 'user changed their mind' );
+} );
+
+it( 'returns false when there is no scheduled deletion to cancel', function (): void {
+	$subject = DeletionSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	expect( app( DataDeletionService::class )->cancelScheduledDeletion( $subject ) )->toBeFalse();
+} );

--- a/tests/Feature/Services/DataExportServiceTest.php
+++ b/tests/Feature/Services/DataExportServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+use ArtisanPackUI\Privacy\Events\DataExportCollecting;
+use ArtisanPackUI\Privacy\Models\Consent;
+use ArtisanPackUI\Privacy\Services\DataExportService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach( function (): void {
+	Relation::morphMap( [ 'export_subject' => ExportSubject::class ] );
+	Schema::create( 'export_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'email' )->nullable();
+		$table->string( 'name' )->nullable();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'export_subjects' );
+} );
+
+class ExportSubject extends Model
+{
+	use HasPersonalData;
+
+	public $timestamps = false;
+
+	protected $table = 'export_subjects';
+
+	protected $guarded = [];
+
+	protected array $personalDataFields = [ 'email', 'name' ];
+
+	public function getMorphClass(): string
+	{
+		return 'export_subject';
+	}
+}
+
+it( 'exports a subject as JSON including personal data', function (): void {
+	$subject = ExportSubject::create( [ 'email' => 'jacob@example.com', 'name' => 'Jacob' ] );
+
+	$json = app( DataExportService::class )->export( $subject, DataExportService::FORMAT_JSON );
+	$data = json_decode( $json, true );
+
+	expect( $data )->toBeArray();
+	expect( $data['personal_data']['email'] )->toBe( 'jacob@example.com' );
+	expect( $data['personal_data']['name'] )->toBe( 'Jacob' );
+	expect( $data )->toHaveKey( 'consent_history' );
+	expect( $data )->toHaveKey( 'activity_log' );
+} );
+
+it( 'exports as CSV with section/key/value rows', function (): void {
+	$subject = ExportSubject::create( [ 'email' => 'jacob@example.com', 'name' => 'Jacob' ] );
+
+	$csv = app( DataExportService::class )->export( $subject, DataExportService::FORMAT_CSV );
+
+	expect( $csv )->toContain( 'section,key,value' );
+	expect( $csv )->toContain( 'jacob@example.com' );
+	expect( $csv )->toContain( 'Jacob' );
+} );
+
+it( 'exports as XML', function (): void {
+	$subject = ExportSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	$xml = app( DataExportService::class )->export( $subject, DataExportService::FORMAT_XML );
+
+	expect( $xml )->toContain( '<?xml' );
+	expect( $xml )->toContain( '<export>' );
+	expect( $xml )->toContain( 'jacob@example.com' );
+} );
+
+it( 'throws for an unsupported format', function (): void {
+	$subject = ExportSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	app( DataExportService::class )->export( $subject, 'pdf' );
+} )->throws( InvalidArgumentException::class );
+
+it( 'dispatches DataExportCollecting and allows listeners to mutate the payload', function (): void {
+	$subject = ExportSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	Event::listen( DataExportCollecting::class, static function ( DataExportCollecting $event ): void {
+		$event->data['analytics'] = [ 'visits' => 42 ];
+	} );
+
+	$json = app( DataExportService::class )->export( $subject, DataExportService::FORMAT_JSON );
+	$data = json_decode( $json, true );
+
+	expect( $data['analytics']['visits'] )->toBe( 42 );
+} );
+
+it( 'includes consent history', function (): void {
+	$subject = ExportSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	Consent::query()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'category'         => 'analytics',
+		'granted'          => true,
+	] );
+
+	$history = app( DataExportService::class )->getConsentHistory( $subject );
+
+	expect( $history )->toHaveCount( 1 );
+	expect( $history[0]['category'] )->toBe( 'analytics' );
+	expect( $history[0]['granted'] )->toBeTrue();
+} );
+
+it( 'writes export to file with a signed download URL and an expiry marker', function (): void {
+	Storage::fake( 'local' );
+	config()->set( 'artisanpack.privacy.export.disk', 'local' );
+
+	$subject = ExportSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	$result = app( DataExportService::class )->exportToFile( $subject, DataExportService::FORMAT_JSON );
+
+	expect( $result )->toHaveKeys( [ 'path', 'url', 'expires_at' ] );
+	Storage::disk( 'local' )->assertExists( $result['path'] );
+	Storage::disk( 'local' )->assertExists( $result['path'] . '.expires' );
+} );

--- a/tests/Feature/Services/VerificationServiceTest.php
+++ b/tests/Feature/Services/VerificationServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use ArtisanPackUI\Privacy\Models\DataRequestLog;
+use ArtisanPackUI\Privacy\Services\VerificationService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\Support\TestSubject;
+
+beforeEach( function (): void {
+	Schema::create( 'test_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'email' )->nullable();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'test_subjects' );
+} );
+
+function makeRequest( string $token = 'tok-12345', ?Illuminate\Support\Carbon $createdAt = null ): DataRequest
+{
+	$subject = TestSubject::create( [ 'email' => 'jacob@example.com' ] );
+
+	$request = DataRequest::query()->create( [
+		'requestable_type'   => $subject->getMorphClass(),
+		'requestable_id'     => $subject->getKey(),
+		'type'               => DataRequest::TYPE_ACCESS,
+		'status'             => DataRequest::STATUS_PENDING,
+		'verification_token' => $token,
+	] );
+
+	if ( null !== $createdAt ) {
+		$request->forceFill( [ 'created_at' => $createdAt ] )->save();
+		$request->setRawAttributes( $request->getAttributes(), true );
+	}
+
+	return $request;
+}
+
+it( 'finds a request by token', function (): void {
+	$request = makeRequest( 'abc-def' );
+
+	expect( app( VerificationService::class )->findByToken( 'abc-def' )?->id )->toBe( $request->id );
+} );
+
+it( 'returns null for a missing token', function (): void {
+	makeRequest( 'abc-def' );
+
+	expect( app( VerificationService::class )->findByToken( 'no-match' ) )->toBeNull();
+} );
+
+it( 'confirms a pending request and writes an audit-log entry', function (): void {
+	$request = makeRequest();
+
+	$result = app( VerificationService::class )->confirm( $request, 'email' );
+
+	expect( $result )->toBeTrue();
+	$request->refresh();
+	expect( $request->verified_at )->not->toBeNull();
+	expect( $request->status )->toBe( DataRequest::STATUS_PROCESSING );
+
+	$log = DataRequestLog::query()->where( 'data_request_id', $request->id )->first();
+	expect( $log?->action )->toBe( 'verification.confirmed' );
+} );
+
+it( 'refuses to confirm an already-verified request', function (): void {
+	$request = makeRequest();
+	$request->update( [ 'verified_at' => now() ] );
+
+	expect( app( VerificationService::class )->confirm( $request ) )->toBeFalse();
+} );
+
+it( 'refuses to confirm an expired request', function (): void {
+	config()->set( 'artisanpack.privacy.verification.token_ttl_minutes', 1 );
+
+	$request = makeRequest( 'tok-old', now()->subMinutes( 60 ) );
+
+	expect( app( VerificationService::class )->isExpired( $request ) )->toBeTrue();
+	expect( app( VerificationService::class )->confirm( $request ) )->toBeFalse();
+} );
+
+it( 'manually verifies a request with the admin id recorded on the audit log', function (): void {
+	$request = makeRequest();
+
+	app( VerificationService::class )->manuallyVerify( $request, 99 );
+
+	$log = DataRequestLog::query()->where( 'data_request_id', $request->id )->first();
+	expect( $log?->performed_by )->toBe( 99 );
+} );
+
+it( 'refreshes a token and clears verified_at', function (): void {
+	$request = makeRequest( 'tok-original' );
+	$request->update( [ 'verified_at' => now() ] );
+
+	$new = app( VerificationService::class )->refreshToken( $request );
+
+	$request->refresh();
+	expect( $new )->not->toBe( 'tok-original' );
+	expect( $request->verification_token )->toBe( $new );
+	expect( $request->verified_at )->toBeNull();
+} );
+
+it( 'builds a verification URL when a token is set', function (): void {
+	$request = makeRequest( 'tok-link' );
+
+	$url = app( VerificationService::class )->verificationUrl( $request );
+
+	expect( $url )->toContain( 'tok-link' );
+} );


### PR DESCRIPTION
## Description

Implements GDPR/CCPA-style data subject rights end-to-end across five related issues. Adds identity verification, data export, deletion, anonymization extensions, and the notification surface that ties them together.

**Closes:** #16, #17, #18, #19, #20

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #16, #17, #18, #19, #20

## Motivation and Context

Data subjects need to exercise their access / portability / deletion / rectification rights against the application. These five issues together complete the request lifecycle: file → verify → process → notify → fulfil. They were grouped into one branch because they share data (DataRequest, ScheduledDeletion, the new notifications) and the verification flow gates the others.

## Changes Made

### #16 Identity verification
- `VerificationService` (issue/find/confirm/expire/refresh/url + `manuallyVerify()` for admin)
- `DataRequestVerificationController` (show + verify) wired to `routes/web.php` under the package prefix
- Server-rendered Blade view (`resources/views/verification/show.blade.php`)
- Parallel UI components: Livewire (`VerifyDataRequest` + view), React (`VerifyDataRequest.tsx`), Vue (`VerifyDataRequest.vue`); all three exported from the package barrels
- Named `privacy-verification` rate limiter registered in the service provider; config knobs in `verification.token_ttl_minutes` and `verification.rate_limit`
- `ProcessDataAccessRequest` / `ProcessDataExportRequest` now respect `require_verification` so auto-promotion only runs once `verified_at` is set

### #17 DataExportService
- New `DataExportService` with `export()`, `exportToFile()`, `getPersonalData()`, `getConsentHistory()`, `getActivityLog()`, `getRelatedData()`
- JSON / CSV (section,key,value flatten) / XML serializers; CSV uses the explicit-arg signature (PHP 8.5 deprecation-safe)
- `HasPersonalData` trait so consuming apps opt models in via `$personalDataFields` / `$personalDataRelations`
- `DataExportCollecting` event + `applyFilters('privacy.export.data', …)` hook for third-party data injection
- File storage on the configured disk with a sidecar `.expires` marker; `DataExportDownloadController` serves via `URL::temporarySignedRoute` with path-traversal defense in depth
- Per-section row cap (`export.row_cap`, default 10k) prevents OOM on high-volume subjects

### #18 DataDeletionService
- New `DataDeletionService` with `delete()` (delete/anonymize/pseudonymize strategies), `anonymize()`, `pseudonymize()` (deterministic hash; use `STRATEGY_REVERSIBLE_PSEUDONYMIZE` for reversible), `deleteRelated()`, `scheduleForDeletion()`, `cancelScheduledDeletion()`, `processScheduled()`
- `privacy_scheduled_deletions` migration + `ScheduledDeletion` model with `pending`/`due` scopes
- Cascade across the trait's `personalDataRelations()` with `cascade => false` on children to prevent recursion
- `DataSubjectDeleted` and `DataSubjectDeletionScheduled` events

### #19 AnonymizationService (extended)
- `anonymize(Model, ?array $fields)` overload: explicit `column => strategy` map, numeric list shorthand, or null for pattern-based discovery
- `anonymizeBatch(iterable, ?array)` returning the mutated count
- `anonymizeField()` alias for the AC contract
- `reversiblePseudonymize` / `reverse()` round-trip via `Crypt::encryptString`
- Audit logging (column names only — never values) gated by `anonymization.audit`

### #20 Notifications
- Abstract `DataRequestNotification` base — `ShouldQueue`, per-key channel config, default database payload
- 6 concrete notifications: `DataRequestReceived`, `DataRequestVerificationRequired` (with token URL), `DataRequestProcessing`, `DataRequestCompleted` (download URL), `DataRequestRejected` (reason), `AdminDataRequestNotification`
- Refactored `NotifyAdminOfRequest` listener to dispatch the admin notification via `Notification::route('mail', …)`
- New `notifications.*` config block (queue + per-key channel overrides)

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS / Laravel Herd
- PHP Version: 8.4.3
- Project Version: 1.0.0-dev (release/1.0)

**Tests Performed:**
1. Full Pest suite — 193/193 passing (450 assertions)
2. Tinker end-to-end for all five services against a real user model (results captured in PR thread)
3. Browser-driven manual verification on `/privacy-test/data-rights` in the dev app (separate dev-app PR) — verification flow (Livewire + React + Vue), all 6 export buttons, anonymize/pseudonymize/schedule/cancel deletion, all 6 notification dispatches
4. Path-traversal guard verified via signed-URL controller test (refuses `..` and paths outside the configured directory)

## Accessibility Tests Run

- [x] Keyboard navigation tested (verification page form is reachable and submittable via tab/enter)
- [ ] Screen reader tested (server-rendered Blade verification view uses semantic headings + a single submit button; deferred)
- [ ] Color contrast verified (uses host-app theme; inline minimal CSS only on package-shipped Blade fallback)
- [ ] ARIA labels checked (no custom widgets added; standard buttons/links)

**Details:** Verification UI relies on the host app's design system for styling; the package's shipped Blade view is a minimal fallback that uses semantic markup only.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Feature/Services/AnonymizationServiceTest.php` — +7 tests (explicit fields, numeric list, batch, reversible round-trip, alias)
- `tests/Feature/Services/DataExportServiceTest.php` — 7 tests (JSON/CSV/XML, unsupported format, event listener mutation, consent history, file export)
- `tests/Feature/Services/DataDeletionServiceTest.php` — 7 tests (anonymize/delete/pseudonymize, unknown strategy, schedule/cancel)
- `tests/Feature/Services/VerificationServiceTest.php` — 8 tests (find, confirm guards, expiry, manual, refresh, URL)
- `tests/Feature/Notifications/DataRequestNotificationsTest.php` — 6 tests (channel resolution, each mail payload, downloadable URL, rejection reason)
- `tests/Feature/Http/Controllers/DataRequestVerificationControllerTest.php` — 5 tests (show 200, 404, POST→processing, expired, POST 404)
- `tests/Feature/Http/Controllers/DataExportDownloadControllerTest.php` — 5 tests (signed-URL pass, tampered fail, expired sidecar, path traversal, missing file)

193/193 tests passing. `php-cs-fixer` and `phpcs` clean.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** All new classes, methods, and config keys carry PHPDoc per the project's standard. README + wiki updates can land in a follow-up.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed (basic keyboard nav; full audit deferred)
- [x] Code follows project style guide
- [x] Self-review completed (local /review pass applied 3 MUST + 4 SHOULD fixes before push)
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added identity verification workflow for privacy requests with customizable token expiration
  * Implemented data export functionality with file downloads and configurable retention periods
  * Introduced scheduled deletion with configurable grace periods before processing
  * Added email notifications to admins and users throughout the privacy request lifecycle
  * Enabled multiple data deletion strategies: hard delete, anonymization, and pseudonymization
  * Added verification UI components (React, Vue, and Livewire) for request confirmation

* **Tests**
  * Added comprehensive test coverage for all new privacy features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->