### PR TITLE
feat: privacy dashboard + data-mapping foundation (#21-#25)

### DIFF
--- a/config/artisanpack/privacy.php
+++ b/config/artisanpack/privacy.php
@@ -150,6 +150,15 @@ return [
 		'export_format' => env( 'PRIVACY_EXPORT_FORMAT', 'json' ),
 		'notify_admin'  => true,
 		'admin_email'   => env( 'PRIVACY_ADMIN_EMAIL' ),
+
+		/*
+		| Per-user rate limit applied to the JSON `/data-requests` endpoints
+		| (both index and store) as `hits,minutes`. Keyed by authenticated
+		| user when present, otherwise by IP. Tune down for tighter
+		| enumeration protection; tune up for high-traffic dashboard
+		| polling.
+		*/
+		'api_rate_limit' => env( 'PRIVACY_DATA_REQUESTS_API_RATE_LIMIT', '60,1' ),
 	],
 
 	/*

--- a/resources/js/react/PrivacyDashboard.tsx
+++ b/resources/js/react/PrivacyDashboard.tsx
@@ -1,0 +1,228 @@
+/**
+ * PrivacyDashboard — React privacy hub for authenticated users.
+ *
+ * Composes ConsentPreferences and DataRequestForm with a history table
+ * fed by `GET /api/privacy/data-requests`. Refreshes history whenever a
+ * new request is submitted via the embedded form.
+ *
+ * @since 1.0.0
+ */
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { ConsentPreferences } from './ConsentPreferences';
+import { DataRequestForm, type DataRequestResult } from './DataRequestForm';
+import { useConsent, type UseConsentOptions } from './useConsent';
+
+export interface PrivacyDashboardRequest {
+	id: number;
+	type: string;
+	status: string;
+	regulation: string | null;
+	created_at: string | null;
+	due_at: string | null;
+	completed_at: string | null;
+	download_url: string | null;
+}
+
+export interface PrivacyDashboardHistoryPayload {
+	regulation: string | null;
+	requests: PrivacyDashboardRequest[];
+}
+
+export interface PrivacyDashboardProps extends UseConsentOptions {
+	className?: string;
+	policyUrl?: string;
+	historyEndpoint?: string;
+	requestsEndpoint?: string;
+	historyLimit?: number;
+	showConsent?: boolean;
+	showRequestForm?: boolean;
+	showHistory?: boolean;
+	heading?: ReactNode;
+	csrfToken?: string;
+	fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_HISTORY_ENDPOINT = '/api/privacy/data-requests';
+const DEFAULT_REQUESTS_ENDPOINT = '/api/privacy/data-requests';
+
+function formatDate( iso: string | null ): string {
+	if ( null === iso ) {
+		return '—';
+	}
+	const parsed = new Date( iso );
+	if ( Number.isNaN( parsed.getTime() ) ) {
+		return iso;
+	}
+	return parsed.toLocaleDateString();
+}
+
+function capitalise( value: string ): string {
+	if ( '' === value ) {
+		return value;
+	}
+	return value.charAt( 0 ).toUpperCase() + value.slice( 1 );
+}
+
+export function PrivacyDashboard( props: PrivacyDashboardProps ): JSX.Element {
+	const {
+		className,
+		policyUrl,
+		historyEndpoint = DEFAULT_HISTORY_ENDPOINT,
+		requestsEndpoint = DEFAULT_REQUESTS_ENDPOINT,
+		historyLimit = 25,
+		showConsent = true,
+		showRequestForm = true,
+		showHistory = true,
+		heading,
+		csrfToken,
+		fetchImpl,
+		...consentOptions
+	} = props;
+
+	const consent = useConsent( consentOptions );
+	const [ history, setHistory ] = useState<PrivacyDashboardHistoryPayload | null>( null );
+	const [ loadingHistory, setLoadingHistory ] = useState( false );
+	const [ historyError, setHistoryError ] = useState<string | null>( null );
+
+	const fetcher = useMemo<typeof fetch>( () => {
+		if ( fetchImpl ) {
+			return fetchImpl;
+		}
+		if ( typeof globalThis !== 'undefined' && 'function' === typeof globalThis.fetch ) {
+			return globalThis.fetch.bind( globalThis ) as typeof fetch;
+		}
+		return ( () => Promise.reject( new Error( 'fetch is not available' ) ) ) as typeof fetch;
+	}, [ fetchImpl ] );
+
+	const loadHistory = useCallback( async (): Promise<void> => {
+		if ( ! showHistory ) {
+			return;
+		}
+		setLoadingHistory( true );
+		setHistoryError( null );
+		try {
+			const url = `${ historyEndpoint.replace( /\/+$/, '' ) }?limit=${ historyLimit }`;
+			const response = await fetcher( url, {
+				method: 'GET',
+				credentials: 'same-origin',
+				headers: {
+					Accept: 'application/json',
+					'X-Requested-With': 'XMLHttpRequest',
+				},
+			} );
+			if ( ! response.ok ) {
+				throw new Error( `Failed to load history (${ response.status })` );
+			}
+			const payload = ( await response.json() ) as PrivacyDashboardHistoryPayload;
+			setHistory( payload );
+		} catch ( err ) {
+			setHistoryError( err instanceof Error ? err.message : String( err ) );
+		} finally {
+			setLoadingHistory( false );
+		}
+	}, [ fetcher, historyEndpoint, historyLimit, showHistory ] );
+
+	useEffect( () => {
+		void loadHistory();
+	}, [ loadHistory ] );
+
+	const handleSubmitted = useCallback(
+		( _result: DataRequestResult ): void => {
+			void loadHistory();
+		},
+		[ loadHistory ],
+	);
+
+	const regulation = history?.regulation ?? consent.state?.regulation ?? null;
+
+	return (
+		<div className={ className ?? 'privacy-dashboard' }>
+			<header className="privacy-dashboard__header">
+				{ heading ?? <h2>Your privacy dashboard</h2> }
+				<p>Review your consent settings, file data requests, and download completed exports.</p>
+				{ null !== regulation && (
+					<p className="privacy-dashboard__regulation" aria-live="polite">
+						Regulation: <strong>{ regulation.toUpperCase() }</strong>
+					</p>
+				) }
+				{ policyUrl && (
+					<p>
+						<a href={ policyUrl } className="privacy-dashboard__policy-link">
+							Read our privacy policy
+						</a>
+					</p>
+				) }
+			</header>
+
+			{ showConsent && (
+				<section aria-labelledby="privacy-dashboard-consent-heading" className="privacy-dashboard__section">
+					<h3 id="privacy-dashboard-consent-heading">Consent preferences</h3>
+					<ConsentPreferences { ...consentOptions } />
+				</section>
+			) }
+
+			{ showRequestForm && (
+				<section aria-labelledby="privacy-dashboard-request-heading" className="privacy-dashboard__section">
+					<h3 id="privacy-dashboard-request-heading">Submit a privacy request</h3>
+					<DataRequestForm
+						endpoint={ requestsEndpoint }
+						csrfToken={ csrfToken }
+						fetchImpl={ fetcher }
+						onSubmitted={ handleSubmitted }
+					/>
+				</section>
+			) }
+
+			{ showHistory && (
+				<section
+					aria-labelledby="privacy-dashboard-history-heading"
+					className="privacy-dashboard__section"
+				>
+					<h3 id="privacy-dashboard-history-heading">Request history</h3>
+					{ loadingHistory && <p aria-busy="true">Loading…</p> }
+					{ null !== historyError && (
+						<p role="alert" className="privacy-dashboard__error">
+							{ historyError }
+						</p>
+					) }
+					{ ! loadingHistory && null !== history && 0 === history.requests.length && (
+						<p>You have not filed any privacy requests yet.</p>
+					) }
+					{ null !== history && history.requests.length > 0 && (
+						<table className="privacy-dashboard__table">
+							<thead>
+								<tr>
+									<th scope="col">Type</th>
+									<th scope="col">Status</th>
+									<th scope="col">Filed</th>
+									<th scope="col">Due</th>
+									<th scope="col">Actions</th>
+								</tr>
+							</thead>
+							<tbody>
+								{ history.requests.map( ( request ) => (
+									<tr key={ request.id }>
+										<td>{ capitalise( request.type ) }</td>
+										<td>{ capitalise( request.status ) }</td>
+										<td>{ formatDate( request.created_at ) }</td>
+										<td>{ formatDate( request.due_at ) }</td>
+										<td>
+											{ request.download_url ? (
+												<a href={ request.download_url } rel="noopener">
+													Download export
+												</a>
+											) : (
+												'—'
+											) }
+										</td>
+									</tr>
+								) ) }
+							</tbody>
+						</table>
+					) }
+				</section>
+			) }
+		</div>
+	);
+}

--- a/resources/js/react/index.ts
+++ b/resources/js/react/index.ts
@@ -12,6 +12,12 @@ export { DataRequestForm } from './DataRequestForm';
 export type { DataRequestFormProps, DataRequestResult, DataRequestType } from './DataRequestForm';
 export { VerifyDataRequest } from './VerifyDataRequest';
 export type { VerifyDataRequestProps } from './VerifyDataRequest';
+export { PrivacyDashboard } from './PrivacyDashboard';
+export type {
+	PrivacyDashboardProps,
+	PrivacyDashboardRequest,
+	PrivacyDashboardHistoryPayload,
+} from './PrivacyDashboard';
 export { useConsent } from './useConsent';
 export type { UseConsentOptions, UseConsentResult } from './useConsent';
 export type {

--- a/resources/js/vue/PrivacyDashboard.vue
+++ b/resources/js/vue/PrivacyDashboard.vue
@@ -12,7 +12,7 @@
 import { computed, onMounted, ref } from 'vue';
 import ConsentPreferences from './ConsentPreferences.vue';
 import DataRequestForm, { type DataRequestResult } from './DataRequestForm.vue';
-import { useConsent } from './useConsent';
+import { useConsent, type UseConsentOptions } from './useConsent';
 
 export interface PrivacyDashboardRequest {
 	id: number;
@@ -30,7 +30,7 @@ export interface PrivacyDashboardHistoryPayload {
 	requests: PrivacyDashboardRequest[];
 }
 
-interface PrivacyDashboardProps {
+interface PrivacyDashboardProps extends UseConsentOptions {
 	className?: string;
 	policyUrl?: string;
 	historyEndpoint?: string;
@@ -53,7 +53,15 @@ const props = withDefaults( defineProps<PrivacyDashboardProps>(), {
 	showHistory: true,
 } );
 
-const consent = useConsent();
+const consentOptions = computed<UseConsentOptions>( () => ( {
+	baseUrl: props.baseUrl,
+	csrfToken: props.csrfToken,
+	fetch: props.fetch,
+	client: props.client,
+	skipInitialLoad: props.skipInitialLoad,
+} ) );
+
+const consent = useConsent( consentOptions.value );
 const history = ref<PrivacyDashboardHistoryPayload | null>( null );
 const loadingHistory = ref( false );
 const historyError = ref<string | null>( null );

--- a/resources/js/vue/PrivacyDashboard.vue
+++ b/resources/js/vue/PrivacyDashboard.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+/**
+ * PrivacyDashboard — Vue privacy hub for authenticated users.
+ *
+ * Composes ConsentPreferences and DataRequestForm with a history table
+ * fed by `GET /api/privacy/data-requests`. Refreshes history whenever
+ * a new request is submitted via the embedded form.
+ *
+ * @since 1.0.0
+ */
+
+import { computed, onMounted, ref } from 'vue';
+import ConsentPreferences from './ConsentPreferences.vue';
+import DataRequestForm, { type DataRequestResult } from './DataRequestForm.vue';
+import { useConsent } from './useConsent';
+
+export interface PrivacyDashboardRequest {
+	id: number;
+	type: string;
+	status: string;
+	regulation: string | null;
+	created_at: string | null;
+	due_at: string | null;
+	completed_at: string | null;
+	download_url: string | null;
+}
+
+export interface PrivacyDashboardHistoryPayload {
+	regulation: string | null;
+	requests: PrivacyDashboardRequest[];
+}
+
+interface PrivacyDashboardProps {
+	className?: string;
+	policyUrl?: string;
+	historyEndpoint?: string;
+	requestsEndpoint?: string;
+	historyLimit?: number;
+	showConsent?: boolean;
+	showRequestForm?: boolean;
+	showHistory?: boolean;
+	csrfToken?: string;
+	fetchImpl?: typeof fetch;
+}
+
+const props = withDefaults( defineProps<PrivacyDashboardProps>(), {
+	className: 'privacy-dashboard',
+	historyEndpoint: '/api/privacy/data-requests',
+	requestsEndpoint: '/api/privacy/data-requests',
+	historyLimit: 25,
+	showConsent: true,
+	showRequestForm: true,
+	showHistory: true,
+} );
+
+const consent = useConsent();
+const history = ref<PrivacyDashboardHistoryPayload | null>( null );
+const loadingHistory = ref( false );
+const historyError = ref<string | null>( null );
+
+function fetcher(): typeof fetch {
+	if ( props.fetchImpl ) {
+		return props.fetchImpl;
+	}
+	if ( typeof globalThis !== 'undefined' && 'function' === typeof globalThis.fetch ) {
+		return globalThis.fetch.bind( globalThis ) as typeof fetch;
+	}
+	return ( () => Promise.reject( new Error( 'fetch is not available' ) ) ) as typeof fetch;
+}
+
+function formatDate( iso: string | null ): string {
+	if ( null === iso ) {
+		return '—';
+	}
+	const parsed = new Date( iso );
+	if ( Number.isNaN( parsed.getTime() ) ) {
+		return iso;
+	}
+	return parsed.toLocaleDateString();
+}
+
+function capitalise( value: string ): string {
+	if ( '' === value ) {
+		return value;
+	}
+	return value.charAt( 0 ).toUpperCase() + value.slice( 1 );
+}
+
+async function loadHistory(): Promise<void> {
+	if ( ! props.showHistory ) {
+		return;
+	}
+	loadingHistory.value = true;
+	historyError.value = null;
+	try {
+		const url = `${ props.historyEndpoint.replace( /\/+$/, '' ) }?limit=${ props.historyLimit }`;
+		const response = await fetcher()( url, {
+			method: 'GET',
+			credentials: 'same-origin',
+			headers: {
+				Accept: 'application/json',
+				'X-Requested-With': 'XMLHttpRequest',
+			},
+		} );
+		if ( ! response.ok ) {
+			throw new Error( `Failed to load history (${ response.status })` );
+		}
+		history.value = ( await response.json() ) as PrivacyDashboardHistoryPayload;
+	} catch ( err ) {
+		historyError.value = err instanceof Error ? err.message : String( err );
+	} finally {
+		loadingHistory.value = false;
+	}
+}
+
+function handleSubmitted( _result: DataRequestResult ): void {
+	void loadHistory();
+}
+
+const regulation = computed<string | null>(
+	() => history.value?.regulation ?? consent.state.value?.regulation ?? null,
+);
+
+onMounted( () => {
+	void loadHistory();
+} );
+</script>
+
+<template>
+	<div :class="props.className">
+		<header class="privacy-dashboard__header">
+			<slot name="heading">
+				<h2>Your privacy dashboard</h2>
+			</slot>
+			<p>Review your consent settings, file data requests, and download completed exports.</p>
+			<p v-if="regulation !== null" class="privacy-dashboard__regulation" aria-live="polite">
+				Regulation: <strong>{{ regulation.toUpperCase() }}</strong>
+			</p>
+			<p v-if="props.policyUrl">
+				<a :href="props.policyUrl" class="privacy-dashboard__policy-link">
+					Read our privacy policy
+				</a>
+			</p>
+		</header>
+
+		<section
+			v-if="props.showConsent"
+			aria-labelledby="privacy-dashboard-consent-heading-vue"
+			class="privacy-dashboard__section"
+		>
+			<h3 id="privacy-dashboard-consent-heading-vue">Consent preferences</h3>
+			<ConsentPreferences />
+		</section>
+
+		<section
+			v-if="props.showRequestForm"
+			aria-labelledby="privacy-dashboard-request-heading-vue"
+			class="privacy-dashboard__section"
+		>
+			<h3 id="privacy-dashboard-request-heading-vue">Submit a privacy request</h3>
+			<DataRequestForm
+				:endpoint="props.requestsEndpoint"
+				:csrf-token="props.csrfToken"
+				:fetch-impl="props.fetchImpl"
+				@submitted="handleSubmitted"
+			/>
+		</section>
+
+		<section
+			v-if="props.showHistory"
+			aria-labelledby="privacy-dashboard-history-heading-vue"
+			class="privacy-dashboard__section"
+		>
+			<h3 id="privacy-dashboard-history-heading-vue">Request history</h3>
+			<p v-if="loadingHistory" aria-busy="true">Loading…</p>
+			<p v-if="historyError !== null" role="alert" class="privacy-dashboard__error">
+				{{ historyError }}
+			</p>
+			<p v-if="! loadingHistory && history !== null && history.requests.length === 0">
+				You have not filed any privacy requests yet.
+			</p>
+			<table v-if="history !== null && history.requests.length > 0" class="privacy-dashboard__table">
+				<thead>
+					<tr>
+						<th scope="col">Type</th>
+						<th scope="col">Status</th>
+						<th scope="col">Filed</th>
+						<th scope="col">Due</th>
+						<th scope="col">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="request in history.requests" :key="request.id">
+						<td>{{ capitalise( request.type ) }}</td>
+						<td>{{ capitalise( request.status ) }}</td>
+						<td>{{ formatDate( request.created_at ) }}</td>
+						<td>{{ formatDate( request.due_at ) }}</td>
+						<td>
+							<a v-if="request.download_url" :href="request.download_url" rel="noopener">
+								Download export
+							</a>
+							<span v-else>—</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</section>
+	</div>
+</template>

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -8,6 +8,11 @@ export { default as CookieBanner } from './CookieBanner.vue';
 export { default as ConsentPreferences } from './ConsentPreferences.vue';
 export { default as DataRequestForm } from './DataRequestForm.vue';
 export { default as VerifyDataRequest } from './VerifyDataRequest.vue';
+export { default as PrivacyDashboard } from './PrivacyDashboard.vue';
+export type {
+	PrivacyDashboardRequest,
+	PrivacyDashboardHistoryPayload,
+} from './PrivacyDashboard.vue';
 export { useConsent } from './useConsent';
 export type { UseConsentOptions, UseConsentResult } from './useConsent';
 export type {

--- a/resources/views/livewire/privacy-dashboard.blade.php
+++ b/resources/views/livewire/privacy-dashboard.blade.php
@@ -6,7 +6,7 @@
 	@endphp
 
 	<header class="space-y-2">
-		<h2 class="text-2xl font-semibold">{{ __( 'Your privacy dashboard' ) }}</h2>
+		<h2 class="text-2xl font-semibold">{{ $heading ?? __( 'Your privacy dashboard' ) }}</h2>
 		<p class="opacity-70">{{ __( 'Review your consent settings, file data requests, and download completed exports.' ) }}</p>
 
 		@if($regulation)
@@ -70,9 +70,9 @@
 							<tbody>
 								@foreach($requests as $request)
 									<tr wire:key="privacy-dashboard-request-{{ $request->id }}">
-										<td>{{ __( ucfirst( $request->type ) ) }}</td>
+										<td>{{ $this->typeLabel( $request->type ) }}</td>
 										<td>
-											<span class="badge badge-ghost">{{ __( ucfirst( $request->status ) ) }}</span>
+											<span class="badge badge-ghost">{{ $this->statusLabel( $request->status ) }}</span>
 										</td>
 										<td>{{ optional( $request->created_at )->toFormattedDateString() }}</td>
 										<td>

--- a/resources/views/livewire/privacy-dashboard.blade.php
+++ b/resources/views/livewire/privacy-dashboard.blade.php
@@ -1,0 +1,104 @@
+<div class="privacy-dashboard space-y-8">
+	@php
+		$subject = $this->subject;
+		$regulation = $this->regulation;
+		$requests = $this->requests;
+	@endphp
+
+	<header class="space-y-2">
+		<h2 class="text-2xl font-semibold">{{ __( 'Your privacy dashboard' ) }}</h2>
+		<p class="opacity-70">{{ __( 'Review your consent settings, file data requests, and download completed exports.' ) }}</p>
+
+		@if($regulation)
+			<div class="text-sm opacity-80" aria-live="polite">
+				<span class="badge badge-ghost">{{ __( 'Regulation' ) }}: {{ strtoupper( $regulation ) }}</span>
+			</div>
+		@endif
+
+		@if($policyUrl)
+			<p>
+				<a href="{{ $policyUrl }}" class="link link-primary text-sm">
+					{{ __( 'Read our privacy policy' ) }}
+				</a>
+			</p>
+		@endif
+	</header>
+
+	@if(! $subject)
+		<div class="alert alert-warning" role="alert">
+			<span>{{ __( 'Please sign in to view your privacy dashboard.' ) }}</span>
+		</div>
+	@else
+		@if($showConsent)
+			<section aria-labelledby="privacy-dashboard-consent-heading" class="space-y-3">
+				<h3 id="privacy-dashboard-consent-heading" class="text-lg font-medium">
+					{{ __( 'Consent preferences' ) }}
+				</h3>
+				<livewire:privacy-consent-preferences />
+			</section>
+		@endif
+
+		@if($showRequestForm)
+			<section aria-labelledby="privacy-dashboard-request-heading" class="space-y-3">
+				<h3 id="privacy-dashboard-request-heading" class="text-lg font-medium">
+					{{ __( 'Submit a privacy request' ) }}
+				</h3>
+				<livewire:privacy-data-request-form />
+			</section>
+		@endif
+
+		@if($showHistory)
+			<section aria-labelledby="privacy-dashboard-history-heading" class="space-y-3">
+				<h3 id="privacy-dashboard-history-heading" class="text-lg font-medium">
+					{{ __( 'Request history' ) }}
+				</h3>
+
+				@if($requests->isEmpty())
+					<p class="opacity-70">{{ __( 'You have not filed any privacy requests yet.' ) }}</p>
+				@else
+					<div class="overflow-x-auto">
+						<table class="table" wire:key="privacy-dashboard-requests-{{ $requestsVersion }}">
+							<thead>
+								<tr>
+									<th scope="col">{{ __( 'Type' ) }}</th>
+									<th scope="col">{{ __( 'Status' ) }}</th>
+									<th scope="col">{{ __( 'Filed' ) }}</th>
+									<th scope="col">{{ __( 'Due' ) }}</th>
+									<th scope="col" class="text-right">{{ __( 'Actions' ) }}</th>
+								</tr>
+							</thead>
+							<tbody>
+								@foreach($requests as $request)
+									<tr wire:key="privacy-dashboard-request-{{ $request->id }}">
+										<td>{{ __( ucfirst( $request->type ) ) }}</td>
+										<td>
+											<span class="badge badge-ghost">{{ __( ucfirst( $request->status ) ) }}</span>
+										</td>
+										<td>{{ optional( $request->created_at )->toFormattedDateString() }}</td>
+										<td>
+											@if($request->due_at)
+												{{ $request->due_at->toFormattedDateString() }}
+											@else
+												<span class="opacity-60">{{ __( 'n/a' ) }}</span>
+											@endif
+										</td>
+										<td class="text-right">
+											@php $download = $this->downloadUrlFor( $request ); @endphp
+											@if($download)
+												<a class="btn btn-sm btn-primary" href="{{ $download }}" rel="noopener">
+													{{ __( 'Download export' ) }}
+												</a>
+											@else
+												<span class="opacity-60">&mdash;</span>
+											@endif
+										</td>
+									</tr>
+								@endforeach
+							</tbody>
+						</table>
+					</div>
+				@endif
+			</section>
+		@endif
+	@endif
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,5 +23,9 @@ use Illuminate\Support\Facades\Route;
 Route::get( '/consent', [ ConsentApiController::class, 'show' ] )->name( 'privacy.api.consent.show' );
 Route::post( '/consent', [ ConsentApiController::class, 'update' ] )->name( 'privacy.api.consent.update' );
 Route::get( '/categories', CategoriesApiController::class )->name( 'privacy.api.categories' );
-Route::get( '/data-requests', [ DataRequestApiController::class, 'index' ] )->name( 'privacy.api.data-requests.index' );
-Route::post( '/data-requests', [ DataRequestApiController::class, 'store' ] )->name( 'privacy.api.data-requests.store' );
+Route::get( '/data-requests', [ DataRequestApiController::class, 'index' ] )
+	->middleware( 'throttle:privacy-data-requests-api' )
+	->name( 'privacy.api.data-requests.index' );
+Route::post( '/data-requests', [ DataRequestApiController::class, 'store' ] )
+	->middleware( 'throttle:privacy-data-requests-api' )
+	->name( 'privacy.api.data-requests.store' );

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,4 +23,5 @@ use Illuminate\Support\Facades\Route;
 Route::get( '/consent', [ ConsentApiController::class, 'show' ] )->name( 'privacy.api.consent.show' );
 Route::post( '/consent', [ ConsentApiController::class, 'update' ] )->name( 'privacy.api.consent.update' );
 Route::get( '/categories', CategoriesApiController::class )->name( 'privacy.api.categories' );
+Route::get( '/data-requests', [ DataRequestApiController::class, 'index' ] )->name( 'privacy.api.data-requests.index' );
 Route::post( '/data-requests', [ DataRequestApiController::class, 'store' ] )->name( 'privacy.api.data-requests.store' );

--- a/src/Concerns/HasPersonalData.php
+++ b/src/Concerns/HasPersonalData.php
@@ -193,9 +193,18 @@ trait HasPersonalData
 	{
 		$service = app( AnonymizationService::class );
 		$map     = $this->buildAnonymizationMap();
+		$names   = $this->personalDataFieldNames();
 
+		// When the trait declares fields without per-field strategies, pass
+		// the declared names as a numeric list. The service resolves a
+		// strategy for each one from `discovery.field_patterns` — this is
+		// strictly broader than falling through to pattern discovery, which
+		// would silently skip declared columns whose names do not match any
+		// configured pattern.
 		if ( [] === $map ) {
-			return $service->anonymize( $this );
+			return [] === $names
+				? $service->anonymize( $this )
+				: $service->anonymize( $this, $names );
 		}
 
 		return $service->anonymize( $this, $map );
@@ -220,11 +229,16 @@ trait HasPersonalData
 	{
 		$service = app( DataDeletionService::class );
 
-		if ( ! array_key_exists( 'strategy', $options ) ) {
-			$strategy = $this->resolvePreferredDeletionStrategy();
+		$supplied        = $options['strategy'] ?? null;
+		$strategyMissing = ! is_string( $supplied ) || '' === $supplied;
 
-			if ( null !== $strategy ) {
-				$options['strategy'] = $strategy;
+		if ( $strategyMissing ) {
+			$resolved = $this->resolvePreferredDeletionStrategy();
+
+			if ( null !== $resolved ) {
+				$options['strategy'] = $resolved;
+			} else {
+				unset( $options['strategy'] );
 			}
 		}
 

--- a/src/Concerns/HasPersonalData.php
+++ b/src/Concerns/HasPersonalData.php
@@ -16,6 +16,8 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Privacy\Concerns;
 
+use ArtisanPackUI\Privacy\Services\AnonymizationService;
+use ArtisanPackUI\Privacy\Services\DataDeletionService;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 /**
@@ -23,26 +25,80 @@ use Illuminate\Database\Eloquent\Relations\Relation;
  * access/export results and that the deletion service should consider when
  * cascading.
  *
- * Models can either declare `protected array $personalDataFields = []`
- * directly, or override {@see personalDataFields()} for dynamic discovery.
+ * Models can declare fields either as a plain list of column names —
+ *
+ *   protected array $personalDataFields = [ 'email', 'name' ];
+ *
+ * or as a metadata map keyed by column —
+ *
+ *   protected function personalDataFields(): array
+ *   {
+ *       return [
+ *           'email' => [
+ *               'type'              => 'email',
+ *               'sensitivity'       => 'normal',
+ *               'deletion_strategy' => 'anonymize',
+ *           ],
+ *       ];
+ *   }
  *
  * @since 1.0.0
  */
 trait HasPersonalData
 {
 	/**
-	 * Columns whose values represent personal data for this model.
+	 * Field descriptors for the personal data on this model.
 	 *
-	 * Override on the consuming model — either as a property or by
-	 * overriding {@see personalDataFields()}.
+	 * Override on the consuming model — either as a property or by overriding
+	 * this method.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int|string, mixed>
+	 */
+	public function personalDataFields(): array
+	{
+		return property_exists( $this, 'personalDataFields' ) ? (array) $this->personalDataFields : [];
+	}
+
+	/**
+	 * Returns just the column names from {@see personalDataFields()},
+	 * normalising both the plain-list and metadata-map shapes.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return array<int, string>
 	 */
-	public function personalDataFields(): array
+	public function personalDataFieldNames(): array
 	{
-		return property_exists( $this, 'personalDataFields' ) ? (array) $this->personalDataFields : [];
+		$names = [];
+
+		foreach ( $this->personalDataFields() as $key => $value ) {
+			$names[] = is_string( $key ) ? $key : (string) $value;
+		}
+
+		return $names;
+	}
+
+	/**
+	 * Returns the metadata map for a single field, or an empty array when
+	 * the field was declared as a plain name without metadata.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $field Column name to look up.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function personalDataFieldMetadata( string $field ): array
+	{
+		$fields = $this->personalDataFields();
+
+		if ( array_key_exists( $field, $fields ) && is_array( $fields[ $field ] ) ) {
+			return $fields[ $field ];
+		}
+
+		return [];
 	}
 
 	/**
@@ -65,15 +121,28 @@ trait HasPersonalData
 	 *
 	 * @return array<string, mixed>
 	 */
-	public function toPersonalDataArray(): array
+	public function getPersonalData(): array
 	{
 		$data = [];
 
-		foreach ( $this->personalDataFields() as $field ) {
+		foreach ( $this->personalDataFieldNames() as $field ) {
 			$data[ $field ] = $this->getAttribute( $field );
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Alias for {@see getPersonalData()} retained for backward compatibility
+	 * with the original 1.0 API.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toPersonalDataArray(): array
+	{
+		return $this->getPersonalData();
 	}
 
 	/**
@@ -109,5 +178,134 @@ trait HasPersonalData
 		}
 
 		return $out;
+	}
+
+	/**
+	 * Anonymizes the model's declared personal-data fields using the
+	 * per-field metadata when available, falling back to the
+	 * {@see AnonymizationService} defaults otherwise.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True when at least one field was mutated.
+	 */
+	public function anonymizePersonalData(): bool
+	{
+		$service = app( AnonymizationService::class );
+		$map     = $this->buildAnonymizationMap();
+
+		if ( [] === $map ) {
+			return $service->anonymize( $this );
+		}
+
+		return $service->anonymize( $this, $map );
+	}
+
+	/**
+	 * Applies the deletion strategy declared by the model's personal-data
+	 * configuration.
+	 *
+	 * When no per-model strategy is declared, the package falls back to the
+	 * configured `deletion.default_strategy`. Cascades across the relations
+	 * returned by {@see personalDataRelations()}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $options Override flags forwarded to
+	 *                                         {@see DataDeletionService::delete()}.
+	 *
+	 * @return bool
+	 */
+	public function deletePersonalData( array $options = [] ): bool
+	{
+		$service = app( DataDeletionService::class );
+
+		if ( ! array_key_exists( 'strategy', $options ) ) {
+			$strategy = $this->resolvePreferredDeletionStrategy();
+
+			if ( null !== $strategy ) {
+				$options['strategy'] = $strategy;
+			}
+		}
+
+		return $service->delete( $this, $options );
+	}
+
+	/**
+	 * Builds the field → strategy map used by the anonymization service from
+	 * the per-field metadata. Returns an empty array when no field declares
+	 * an explicit strategy, in which case the service uses its defaults.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, string>
+	 */
+	protected function buildAnonymizationMap(): array
+	{
+		$map = [];
+
+		foreach ( $this->personalDataFieldNames() as $field ) {
+			$metadata = $this->personalDataFieldMetadata( $field );
+			$strategy = $metadata['anonymization_strategy'] ?? $metadata['strategy'] ?? null;
+
+			if ( null === $strategy && isset( $metadata['type'] ) ) {
+				$strategy = config( "artisanpack.privacy.anonymization.strategies.{$metadata['type']}" );
+			}
+
+			if ( is_string( $strategy ) && '' !== $strategy ) {
+				$map[ $field ] = $strategy;
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Returns the dominant deletion strategy declared by the model's fields.
+	 *
+	 * When every field declaring a `deletion_strategy` agrees, that value is
+	 * returned. When they disagree, the most common one wins (ties resolved
+	 * by first occurrence). Returns null when no field declares a strategy.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string|null
+	 */
+	protected function resolvePreferredDeletionStrategy(): ?string
+	{
+		$tally = [];
+		$order = [];
+
+		foreach ( $this->personalDataFieldNames() as $field ) {
+			$metadata = $this->personalDataFieldMetadata( $field );
+			$strategy = $metadata['deletion_strategy'] ?? null;
+
+			if ( ! is_string( $strategy ) || '' === $strategy ) {
+				continue;
+			}
+
+			if ( ! array_key_exists( $strategy, $tally ) ) {
+				$tally[ $strategy ] = 0;
+				$order[]            = $strategy;
+			}
+
+			++$tally[ $strategy ];
+		}
+
+		if ( [] === $tally ) {
+			return null;
+		}
+
+		$best  = null;
+		$count = -1;
+
+		foreach ( $order as $strategy ) {
+			if ( $tally[ $strategy ] > $count ) {
+				$best  = $strategy;
+				$count = $tally[ $strategy ];
+			}
+		}
+
+		return $best;
 	}
 }

--- a/src/Console/Commands/PrivacyScan.php
+++ b/src/Console/Commands/PrivacyScan.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * PrivacyScan — `privacy:scan` Artisan command.
+ *
+ * Runs the {@see PersonalDataScanner} against the configured model paths and
+ * optionally persists the result. Output is human-readable by default but
+ * can be switched to `json` or `csv` for integration with downstream tools.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Console\Commands;
+
+use ArtisanPackUI\Privacy\Models\PersonalDataMap;
+use ArtisanPackUI\Privacy\Services\PersonalDataScanner;
+use Illuminate\Console\Command;
+
+/**
+ * Scans the configured models for personal-data fields.
+ *
+ * @since 1.0.0
+ */
+class PrivacyScan extends Command
+{
+	/**
+	 * The console command signature.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'privacy:scan
+		{--model= : Limit the scan to the given fully-qualified model class.}
+		{--save : Persist the discovered mappings to the privacy_personal_data_maps table.}
+		{--format=table : Output format. Supported: table, json, csv.}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Discover personal-data fields across Eloquent models.';
+
+	/**
+	 * Executes the command.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PersonalDataScanner  $scanner Scanner service.
+	 *
+	 * @return int
+	 */
+	public function handle( PersonalDataScanner $scanner ): int
+	{
+		$format = strtolower( (string) $this->option( 'format' ) );
+
+		if ( ! in_array( $format, [ 'table', 'json', 'csv' ], true ) ) {
+			$this->error( "Unsupported format: {$format}. Use table, json, or csv." );
+
+			return self::INVALID;
+		}
+
+		$results = $this->collect( $scanner );
+
+		if ( [] === $results ) {
+			$this->warn( 'No personal-data fields were discovered.' );
+
+			return self::SUCCESS;
+		}
+
+		if ( $this->option( 'save' ) ) {
+			$written = $scanner->persist( $results );
+			$this->info( sprintf( 'Persisted %d field mapping(s).', $written ) );
+		}
+
+		match ( $format ) {
+			'json'  => $this->renderJson( $results ),
+			'csv'   => $this->renderCsv( $results ),
+			default => $this->renderTable( $results, $scanner ),
+		};
+
+		return self::SUCCESS;
+	}
+
+	/**
+	 * Runs the scanner against either the supplied model or every configured
+	 * model path.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PersonalDataScanner  $scanner Scanner service.
+	 *
+	 * @return array<class-string, array<string, array<string, mixed>>>
+	 */
+	protected function collect( PersonalDataScanner $scanner ): array
+	{
+		$model = $this->option( 'model' );
+
+		if ( null !== $model ) {
+			$fields = $scanner->scanModel( (string) $model );
+
+			return [] === $fields ? [] : [ (string) $model => $fields ];
+		}
+
+		return $scanner->scan();
+	}
+
+	/**
+	 * Renders the discovered fields as a console table grouped by model.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<class-string, array<string, array<string, mixed>>>  $results Scanner results.
+	 * @param  PersonalDataScanner                                       $scanner Scanner service.
+	 *
+	 * @return void
+	 */
+	protected function renderTable( array $results, PersonalDataScanner $scanner ): void
+	{
+		$totalFields = 0;
+
+		foreach ( $results as $modelClass => $fields ) {
+			$this->line( '' );
+			$this->line( '<info>' . $modelClass . '</info>' );
+
+			$existing = $scanner->getFieldMappings( $modelClass );
+			$rows     = [];
+
+			foreach ( $fields as $field => $config ) {
+				$totalFields++;
+				$rows[] = [
+					$field,
+					$config['data_type'] ?? 'unknown',
+					$this->formatSensitivity( (string) ( $config['sensitivity'] ?? PersonalDataMap::SENSITIVITY_NORMAL ) ),
+					$config['deletion_strategy'] ?? PersonalDataMap::STRATEGY_ANONYMIZE,
+					$this->formatSource( $config, $existing[ $field ] ?? null ),
+				];
+			}
+
+			$this->table(
+				[ 'Field', 'Type', 'Sensitivity', 'Strategy', 'Source' ],
+				$rows,
+			);
+		}
+
+		$this->line( '' );
+		$this->info( sprintf(
+			'Found %d personal-data field(s) across %d model(s).',
+			$totalFields,
+			count( $results ),
+		) );
+	}
+
+	/**
+	 * Renders the discovered fields as JSON to stdout.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<class-string, array<string, array<string, mixed>>>  $results Scanner results.
+	 *
+	 * @return void
+	 */
+	protected function renderJson( array $results ): void
+	{
+		$this->line(
+			(string) json_encode( $results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+		);
+	}
+
+	/**
+	 * Renders the discovered fields as CSV to stdout.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<class-string, array<string, array<string, mixed>>>  $results Scanner results.
+	 *
+	 * @return void
+	 */
+	protected function renderCsv( array $results ): void
+	{
+		$handle = fopen( 'php://temp', 'r+' );
+
+		fputcsv(
+			$handle,
+			[ 'model', 'field', 'data_type', 'sensitivity', 'deletion_strategy', 'auto_discovered' ],
+			',',
+			'"',
+			'\\',
+		);
+
+		foreach ( $results as $modelClass => $fields ) {
+			foreach ( $fields as $field => $config ) {
+				fputcsv( $handle, [
+					$modelClass,
+					$field,
+					$config['data_type'] ?? 'unknown',
+					$config['sensitivity'] ?? PersonalDataMap::SENSITIVITY_NORMAL,
+					$config['deletion_strategy'] ?? PersonalDataMap::STRATEGY_ANONYMIZE,
+					( $config['auto_discovered'] ?? false ) ? 'true' : 'false',
+				], ',', '"', '\\' );
+			}
+		}
+
+		rewind( $handle );
+		$this->line( (string) stream_get_contents( $handle ) );
+		fclose( $handle );
+	}
+
+	/**
+	 * Returns a human-friendly sensitivity label with a marker on
+	 * sensitive/special-category fields so they stand out in the table.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $sensitivity Sensitivity classification.
+	 *
+	 * @return string
+	 */
+	protected function formatSensitivity( string $sensitivity ): string
+	{
+		return match ( $sensitivity ) {
+			PersonalDataMap::SENSITIVITY_SENSITIVE,
+			PersonalDataMap::SENSITIVITY_SPECIAL_CATEGORY => strtoupper( $sensitivity ) . ' !',
+			default                                       => $sensitivity,
+		};
+	}
+
+	/**
+	 * Returns the "Source" column for a row — combines auto-detection origin
+	 * with a marker that flags drift between this scan and the persisted map.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>       $config    Discovered field config.
+	 * @param  array<string, mixed>|null  $persisted Persisted mapping if any.
+	 *
+	 * @return string
+	 */
+	protected function formatSource( array $config, ?array $persisted ): string
+	{
+		$source = (string) ( $config['source'] ?? ( ( $config['auto_discovered'] ?? false ) ? PersonalDataScanner::SOURCE_PATTERN : PersonalDataScanner::SOURCE_TRAIT ) );
+
+		if ( null === $persisted ) {
+			return $source . ' (new)';
+		}
+
+		$drift = ( $persisted['data_type'] ?? null ) !== ( $config['data_type'] ?? null )
+			|| ( $persisted['sensitivity'] ?? null ) !== ( $config['sensitivity'] ?? null )
+			|| ( $persisted['deletion_strategy'] ?? null ) !== ( $config['deletion_strategy'] ?? null );
+
+		return $drift ? $source . ' (changed)' : $source;
+	}
+}

--- a/src/Console/Commands/PrivacyScan.php
+++ b/src/Console/Commands/PrivacyScan.php
@@ -22,6 +22,8 @@ namespace ArtisanPackUI\Privacy\Console\Commands;
 use ArtisanPackUI\Privacy\Models\PersonalDataMap;
 use ArtisanPackUI\Privacy\Services\PersonalDataScanner;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
 
 /**
  * Scans the configured models for personal-data fields.
@@ -66,6 +68,18 @@ class PrivacyScan extends Command
 			return self::INVALID;
 		}
 
+		$model = $this->option( 'model' );
+
+		if ( null !== $model ) {
+			$class = (string) $model;
+
+			if ( ! class_exists( $class ) || ! is_subclass_of( $class, Model::class ) ) {
+				$this->error( "Model class {$class} could not be resolved as an Eloquent model." );
+
+				return self::INVALID;
+			}
+		}
+
 		$results = $this->collect( $scanner );
 
 		if ( [] === $results ) {
@@ -103,9 +117,17 @@ class PrivacyScan extends Command
 		$model = $this->option( 'model' );
 
 		if ( null !== $model ) {
-			$fields = $scanner->scanModel( (string) $model );
+			$class = (string) $model;
 
-			return [] === $fields ? [] : [ (string) $model => $fields ];
+			if ( ! class_exists( $class ) || ! is_subclass_of( $class, Model::class ) ) {
+				$this->error( "Model class {$class} could not be resolved as an Eloquent model." );
+
+				return [];
+			}
+
+			$fields = $scanner->scanModel( $class );
+
+			return [] === $fields ? [] : [ $class => $fields ];
 		}
 
 		return $scanner->scan();
@@ -185,6 +207,10 @@ class PrivacyScan extends Command
 	protected function renderCsv( array $results ): void
 	{
 		$handle = fopen( 'php://temp', 'r+' );
+
+		if ( false === $handle ) {
+			throw new RuntimeException( 'Failed to open the CSV buffer.' );
+		}
 
 		fputcsv(
 			$handle,

--- a/src/Contracts/PrivacyRegulation.php
+++ b/src/Contracts/PrivacyRegulation.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * PrivacyRegulation contract — common surface for regulation implementations.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Contracts;
+
+use Illuminate\Http\Request;
+
+/**
+ * Contract implemented by every concrete regulation class (GDPR, CCPA, …).
+ *
+ * Concrete implementations live alongside {@see \ArtisanPackUI\Privacy\Regulations\BaseRegulation}
+ * and are looked up by key through the regulation registry.
+ *
+ * @since 1.0.0
+ */
+interface PrivacyRegulation
+{
+	/**
+	 * Returns the stable key used to identify the regulation in config and
+	 * persisted data (`gdpr`, `ccpa`, `lgpd`, …).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function key(): string;
+
+	/**
+	 * Returns the user-friendly display name (`GDPR`, `CCPA`, …).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function name(): string;
+
+	/**
+	 * Returns the consent-related requirements imposed by the regulation —
+	 * for example whether opt-in is required, whether silence counts, etc.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function getConsentRequirements(): array;
+
+	/**
+	 * Returns the data subject rights granted by the regulation as a list of
+	 * stable keys (`access`, `export`, `deletion`, `rectification`, …).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function getDataRights(): array;
+
+	/**
+	 * Returns the retention rules the regulation imposes on stored data,
+	 * keyed by domain (`consent`, `request`, `audit`, …).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function getRetentionRules(): array;
+
+	/**
+	 * Returns the number of hours within which a data breach must be reported
+	 * to the supervisory authority.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	public function getBreachNotificationHours(): int;
+
+	/**
+	 * Returns the number of days the controller has to respond to a request
+	 * of the given type.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $requestType  Request type key (`access`, `export`, …).
+	 *
+	 * @return int
+	 */
+	public function getResponseDays( string $requestType ): int;
+
+	/**
+	 * Returns true when the regulation applies to the supplied request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request  Incoming request to evaluate.
+	 *
+	 * @return bool
+	 */
+	public function applies( Request $request ): bool;
+}

--- a/src/Http/Controllers/Api/DataRequestApiController.php
+++ b/src/Http/Controllers/Api/DataRequestApiController.php
@@ -21,9 +21,11 @@ namespace ArtisanPackUI\Privacy\Http\Controllers\Api;
 
 use ArtisanPackUI\Privacy\Http\Requests\StoreDataRequestRequest;
 use ArtisanPackUI\Privacy\Models\DataRequest;
+use ArtisanPackUI\Privacy\Regulations\RegulationRegistry;
 use ArtisanPackUI\Privacy\Services\DataRequestService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 
@@ -74,5 +76,61 @@ class DataRequestApiController extends Controller
 			'status'            => $result->status,
 			'verification_sent' => (bool) config( 'artisanpack.privacy.data_requests.require_verification', true ),
 		], 201 );
+	}
+
+	/**
+	 * GET /api/privacy/data-requests
+	 *
+	 * Returns the authenticated subject's own request history plus the
+	 * currently-applicable regulation so the dashboard can show both in a
+	 * single round trip.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request             $request HTTP request.
+	 * @param  RegulationRegistry  $registry Regulation registry.
+	 *
+	 * @return JsonResponse
+	 */
+	public function index( Request $request, RegulationRegistry $registry ): JsonResponse
+	{
+		$subject = Auth::user();
+
+		if ( ! $subject instanceof Model ) {
+			return response()->json( [ 'message' => __( 'Authentication required.' ) ], 401 );
+		}
+
+		$limit = max( 1, min( 100, (int) $request->query( 'limit', '25' ) ) );
+
+		$rows = DataRequest::query()
+			->where( 'requestable_type', $subject->getMorphClass() )
+			->where( 'requestable_id', $subject->getKey() )
+			->orderByDesc( 'created_at' )
+			->limit( $limit )
+			->get();
+
+		$applicable = $registry->applicableFor( $request );
+
+		return response()->json( [
+			'regulation' => $applicable?->key(),
+			'requests'   => $rows->map( static function ( DataRequest $row ): array {
+				$payload     = is_array( $row->data ) ? $row->data : [];
+				$downloadUrl = is_string( $payload['download_url'] ?? null ) ? (string) $payload['download_url'] : null;
+
+				return [
+					'id'           => $row->id,
+					'type'         => $row->type,
+					'status'       => $row->status,
+					'regulation'   => $row->regulation,
+					'created_at'   => $row->created_at?->toIso8601String(),
+					'due_at'       => $row->due_at?->toIso8601String(),
+					'completed_at' => $row->completed_at?->toIso8601String(),
+					'download_url' => DataRequest::TYPE_EXPORT === $row->type
+						&& DataRequest::STATUS_COMPLETED === $row->status
+							? $downloadUrl
+							: null,
+				];
+			} )->all(),
+		] );
 	}
 }

--- a/src/Livewire/PrivacyDashboard.php
+++ b/src/Livewire/PrivacyDashboard.php
@@ -78,6 +78,16 @@ class PrivacyDashboard extends Component
 	public ?string $policyUrl = null;
 
 	/**
+	 * Optional override for the dashboard heading. Mirrors the `heading`
+	 * prop / slot on the React and Vue versions so host applications can
+	 * brand the surface consistently across all three.
+	 *
+	 * @var string|null
+	 */
+	#[Locked]
+	public ?string $heading = null;
+
+	/**
 	 * Maximum number of historical requests to show inline.
 	 *
 	 * @var int
@@ -102,6 +112,7 @@ class PrivacyDashboard extends Component
 	 * @param  bool|null     $showHistory     Override the history section visibility.
 	 * @param  string|null   $policyUrl       URL to the privacy policy.
 	 * @param  int|null      $historyLimit    Max historical requests to show.
+	 * @param  string|null   $heading         Override the default heading text.
 	 *
 	 * @return void
 	 */
@@ -111,6 +122,7 @@ class PrivacyDashboard extends Component
 		?bool $showHistory = null,
 		?string $policyUrl = null,
 		?int $historyLimit = null,
+		?string $heading = null,
 	): void {
 		if ( null !== $showConsent ) {
 			$this->showConsent = $showConsent;
@@ -125,6 +137,7 @@ class PrivacyDashboard extends Component
 		}
 
 		$this->policyUrl = $policyUrl;
+		$this->heading   = $heading;
 
 		if ( null !== $historyLimit && $historyLimit > 0 ) {
 			$this->historyLimit = $historyLimit;
@@ -218,6 +231,51 @@ class PrivacyDashboard extends Component
 		$regulation = $resolver->applicableFor();
 
 		return $regulation?->key();
+	}
+
+	/**
+	 * Returns the translated, capitalised label for a request type. The
+	 * static `__()` calls let translation extractors index the strings —
+	 * `__( ucfirst( $type ) )` cannot be extracted because the value is
+	 * resolved at runtime.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $type Request type value from {@see DataRequest}.
+	 *
+	 * @return string
+	 */
+	public function typeLabel( string $type ): string
+	{
+		$labels = [
+			DataRequest::TYPE_ACCESS        => __( 'Access' ),
+			DataRequest::TYPE_EXPORT        => __( 'Export' ),
+			DataRequest::TYPE_DELETION      => __( 'Deletion' ),
+			DataRequest::TYPE_RECTIFICATION => __( 'Rectification' ),
+		];
+
+		return $labels[ $type ] ?? ucfirst( $type );
+	}
+
+	/**
+	 * Returns the translated, capitalised label for a request status.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $status Status value from {@see DataRequest}.
+	 *
+	 * @return string
+	 */
+	public function statusLabel( string $status ): string
+	{
+		$labels = [
+			DataRequest::STATUS_PENDING    => __( 'Pending' ),
+			DataRequest::STATUS_PROCESSING => __( 'Processing' ),
+			DataRequest::STATUS_COMPLETED  => __( 'Completed' ),
+			DataRequest::STATUS_REJECTED   => __( 'Rejected' ),
+		];
+
+		return $labels[ $status ] ?? ucfirst( $status );
 	}
 
 	/**

--- a/src/Livewire/PrivacyDashboard.php
+++ b/src/Livewire/PrivacyDashboard.php
@@ -1,0 +1,265 @@
+<?php
+
+/**
+ * PrivacyDashboard Livewire component — user-facing privacy hub.
+ *
+ * Renders the authenticated visitor's consent settings, lets them file new
+ * data subject requests, shows the history of past requests, and surfaces
+ * download links for completed exports. Composes the existing consent /
+ * data-request components so each section reuses tested behaviour.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Livewire;
+
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+/**
+ * Privacy dashboard for authenticated users.
+ *
+ * Usage:
+ *
+ *   <livewire:privacy-dashboard />
+ *
+ * Optional mount params let host applications customize the layout — for
+ * example, hide the history table when surfacing the dashboard inside a
+ * compact sidebar.
+ *
+ * @since 1.0.0
+ */
+class PrivacyDashboard extends Component
+{
+	/**
+	 * Whether to render the consent preferences section.
+	 *
+	 * @var bool
+	 */
+	#[Locked]
+	public bool $showConsent = true;
+
+	/**
+	 * Whether to render the new-request form section.
+	 *
+	 * @var bool
+	 */
+	#[Locked]
+	public bool $showRequestForm = true;
+
+	/**
+	 * Whether to render the request history section.
+	 *
+	 * @var bool
+	 */
+	#[Locked]
+	public bool $showHistory = true;
+
+	/**
+	 * Optional URL to link the "view privacy policy" anchor at.
+	 *
+	 * @var string|null
+	 */
+	#[Locked]
+	public ?string $policyUrl = null;
+
+	/**
+	 * Maximum number of historical requests to show inline.
+	 *
+	 * @var int
+	 */
+	#[Locked]
+	public int $historyLimit = 25;
+
+	/**
+	 * Cache bumped after a request is submitted so the history table reloads.
+	 *
+	 * @var int
+	 */
+	public int $requestsVersion = 0;
+
+	/**
+	 * Mount the component.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  bool|null     $showConsent     Override the consent section visibility.
+	 * @param  bool|null     $showRequestForm Override the request-form visibility.
+	 * @param  bool|null     $showHistory     Override the history section visibility.
+	 * @param  string|null   $policyUrl       URL to the privacy policy.
+	 * @param  int|null      $historyLimit    Max historical requests to show.
+	 *
+	 * @return void
+	 */
+	public function mount(
+		?bool $showConsent = null,
+		?bool $showRequestForm = null,
+		?bool $showHistory = null,
+		?string $policyUrl = null,
+		?int $historyLimit = null,
+	): void {
+		if ( null !== $showConsent ) {
+			$this->showConsent = $showConsent;
+		}
+
+		if ( null !== $showRequestForm ) {
+			$this->showRequestForm = $showRequestForm;
+		}
+
+		if ( null !== $showHistory ) {
+			$this->showHistory = $showHistory;
+		}
+
+		$this->policyUrl = $policyUrl;
+
+		if ( null !== $historyLimit && $historyLimit > 0 ) {
+			$this->historyLimit = $historyLimit;
+		}
+	}
+
+	/**
+	 * Refresh the history table whenever the request form fires a submitted
+	 * event. Keeps the dashboard's snapshot in sync without forcing the user
+	 * to refresh the page.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	#[On( 'privacy:data-request-submitted' )]
+	public function onRequestSubmitted(): void
+	{
+		$this->requestsVersion++;
+	}
+
+	/**
+	 * Bumps the cache key so the history reload happens on the next render.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	#[On( 'privacy:consent-updated' )]
+	public function onConsentUpdated(): void
+	{
+		// Touching the dashboard is enough for Livewire to re-render the
+		// applicable-regulation badge — no extra state needs flipping.
+	}
+
+	/**
+	 * Returns the authenticated subject the dashboard is built for, or null
+	 * when no user is signed in (the view degrades to a sign-in prompt).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Model|null
+	 */
+	#[Computed]
+	public function subject(): ?Model
+	{
+		$user = Auth::user();
+
+		return $user instanceof Model ? $user : null;
+	}
+
+	/**
+	 * Returns the historical requests filed by the subject, newest first.
+	 *
+	 * Bumping `requestsVersion` forces a re-render (via the table's
+	 * `wire:key`), at which point Livewire's per-request computed cache is
+	 * re-evaluated against the freshly-bumped state.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Collection<int, DataRequest>
+	 */
+	#[Computed]
+	public function requests(): Collection
+	{
+		$subject = $this->subject();
+
+		if ( ! $subject instanceof Model ) {
+			return new Collection();
+		}
+
+		return DataRequest::query()
+			->where( 'requestable_type', $subject->getMorphClass() )
+			->where( 'requestable_id', $subject->getKey() )
+			->orderByDesc( 'created_at' )
+			->limit( $this->historyLimit )
+			->get();
+	}
+
+	/**
+	 * Returns the regulation key applicable to the current request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string|null
+	 */
+	#[Computed]
+	public function regulation(): ?string
+	{
+		$resolver   = app( \ArtisanPackUI\Privacy\Regulations\RegulationRegistry::class );
+		$regulation = $resolver->applicableFor();
+
+		return $regulation?->key();
+	}
+
+	/**
+	 * Returns the URL the user should be sent to for a completed export, or
+	 * null when no download URL is stored.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  DataRequest  $request Persisted request row.
+	 *
+	 * @return string|null
+	 */
+	public function downloadUrlFor( DataRequest $request ): ?string
+	{
+		if ( DataRequest::TYPE_EXPORT !== $request->type ) {
+			return null;
+		}
+
+		if ( DataRequest::STATUS_COMPLETED !== $request->status ) {
+			return null;
+		}
+
+		$payload = $request->data;
+
+		if ( ! is_array( $payload ) ) {
+			return null;
+		}
+
+		$url = $payload['download_url'] ?? null;
+
+		return is_string( $url ) && '' !== $url ? $url : null;
+	}
+
+	/**
+	 * Render the dashboard view.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'privacy::livewire.privacy-dashboard' );
+	}
+}

--- a/src/PrivacyServiceProvider.php
+++ b/src/PrivacyServiceProvider.php
@@ -20,6 +20,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Privacy;
 
+use ArtisanPackUI\Privacy\Console\Commands\PrivacyScan;
 use ArtisanPackUI\Privacy\Console\Commands\PurgeExpiredConsents;
 use ArtisanPackUI\Privacy\Events\ConsentGiven;
 use ArtisanPackUI\Privacy\Events\ConsentWithdrawn;
@@ -37,12 +38,15 @@ use ArtisanPackUI\Privacy\Listeners\SyncConsentOnLogin;
 use ArtisanPackUI\Privacy\Livewire\ConsentPreferences;
 use ArtisanPackUI\Privacy\Livewire\CookieBanner;
 use ArtisanPackUI\Privacy\Livewire\DataRequestForm;
+use ArtisanPackUI\Privacy\Livewire\PrivacyDashboard;
 use ArtisanPackUI\Privacy\Livewire\VerifyDataRequest;
+use ArtisanPackUI\Privacy\Regulations\RegulationRegistry;
 use ArtisanPackUI\Privacy\Services\AnonymizationService;
 use ArtisanPackUI\Privacy\Services\ConsentService;
 use ArtisanPackUI\Privacy\Services\DataDeletionService;
 use ArtisanPackUI\Privacy\Services\DataExportService;
 use ArtisanPackUI\Privacy\Services\DataRequestService;
+use ArtisanPackUI\Privacy\Services\PersonalDataScanner;
 use ArtisanPackUI\Privacy\Services\VerificationService;
 use ArtisanPackUI\Privacy\View\PrivacyDirectives;
 use Illuminate\Auth\Events\Login;
@@ -139,6 +143,12 @@ class PrivacyServiceProvider extends ServiceProvider
 
 		$this->app->singleton( VerificationService::class, fn () => new VerificationService() );
 		$this->app->alias( VerificationService::class, 'privacy.verification' );
+
+		$this->app->singleton( RegulationRegistry::class, fn () => new RegulationRegistry() );
+		$this->app->alias( RegulationRegistry::class, 'privacy.regulations' );
+
+		$this->app->singleton( PersonalDataScanner::class, fn () => new PersonalDataScanner() );
+		$this->app->alias( PersonalDataScanner::class, 'privacy.scanner' );
 	}
 
 	/**
@@ -260,6 +270,7 @@ class PrivacyServiceProvider extends ServiceProvider
 
 		$this->commands( [
 			PurgeExpiredConsents::class,
+			PrivacyScan::class,
 		] );
 	}
 
@@ -435,5 +446,6 @@ class PrivacyServiceProvider extends ServiceProvider
 		\Livewire\Livewire::component( 'privacy-consent-preferences', ConsentPreferences::class );
 		\Livewire\Livewire::component( 'privacy-data-request-form', DataRequestForm::class );
 		\Livewire\Livewire::component( 'privacy-verify-data-request', VerifyDataRequest::class );
+		\Livewire\Livewire::component( 'privacy-dashboard', PrivacyDashboard::class );
 	}
 }

--- a/src/PrivacyServiceProvider.php
+++ b/src/PrivacyServiceProvider.php
@@ -227,6 +227,18 @@ class PrivacyServiceProvider extends ServiceProvider
 				(int) $hits,
 			)->by( $request->ip() ?: 'anon' );
 		} );
+
+		$apiRule                  = (string) config( 'artisanpack.privacy.data_requests.api_rate_limit', '60,1' );
+		[ $apiHits, $apiMinutes ] = array_pad( explode( ',', $apiRule ), 2, '1' );
+
+		RateLimiter::for( 'privacy-data-requests-api', static function ( $request ) use ( $apiHits, $apiMinutes ) {
+			$key = $request->user()?->getAuthIdentifier();
+
+			return Limit::perMinutes(
+				(int) $apiMinutes,
+				(int) $apiHits,
+			)->by( null !== $key ? "user:{$key}" : ( $request->ip() ?: 'anon' ) );
+		} );
 	}
 
 	/**

--- a/src/Regulations/BaseRegulation.php
+++ b/src/Regulations/BaseRegulation.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * BaseRegulation — shared base for every supported privacy regulation.
+ *
+ * Concrete subclasses (GDPR, CCPA, LGPD, PIPEDA, …) extend this class to
+ * declare their per-regulation requirements while inheriting config-driven
+ * defaults for breach windows, response deadlines, and region matching.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Regulations;
+
+use ArtisanPackUI\Privacy\Contracts\PrivacyRegulation;
+use Illuminate\Http\Request;
+
+/**
+ * Abstract base every concrete regulation extends.
+ *
+ * Subclasses customize {@see consentRequirements()}, {@see dataRights()},
+ * {@see retentionRules()}, and {@see defaultResponseDays()}; the remaining
+ * surface is satisfied here using `artisanpack.privacy.regulations.{key}`.
+ *
+ * @since 1.0.0
+ */
+abstract class BaseRegulation implements PrivacyRegulation
+{
+	/**
+	 * Stable identifier used in config and persisted data.
+	 *
+	 * @var string
+	 */
+	protected string $key = '';
+
+	/**
+	 * Human-readable display name.
+	 *
+	 * @var string
+	 */
+	protected string $name = '';
+
+	/**
+	 * Default breach notification window in hours. Overridden by
+	 * `regulations.{key}.breach_notification_hours` when configured.
+	 *
+	 * @var int
+	 */
+	protected int $defaultBreachNotificationHours = 72;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function key(): string
+	{
+		return $this->key;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function name(): string
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getConsentRequirements(): array
+	{
+		return $this->consentRequirements();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getDataRights(): array
+	{
+		return $this->dataRights();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getRetentionRules(): array
+	{
+		return $this->retentionRules();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getBreachNotificationHours(): int
+	{
+		$configured = config( "artisanpack.privacy.regulations.{$this->key}.breach_notification_hours" );
+
+		return null === $configured ? $this->defaultBreachNotificationHours : (int) $configured;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getResponseDays( string $requestType ): int
+	{
+		$configured = config( "artisanpack.privacy.data_requests.response_days.{$this->key}" );
+
+		if ( null !== $configured ) {
+			return (int) $configured;
+		}
+
+		$default = $this->defaultResponseDays();
+
+		return $default[ $requestType ] ?? $default['default'] ?? 30;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * Default match: the regulation `applies_to` list (configured under
+	 * `regulations.{key}.applies_to`) contains a region recorded on the
+	 * request — either as the `X-Region` header (CDN-friendly), the
+	 * `privacy_region` request attribute (populated by upstream middleware),
+	 * or the `geolocation.fallback_region` config value.
+	 *
+	 * Subclasses may override to add provider-specific lookups (IP, account
+	 * preferences, etc.) without re-implementing the base check.
+	 */
+	public function applies( Request $request ): bool
+	{
+		if ( ! $this->isEnabled() ) {
+			return false;
+		}
+
+		$region = $this->resolveRegion( $request );
+
+		if ( null === $region ) {
+			return false;
+		}
+
+		return in_array( strtoupper( $region ), $this->regions(), true );
+	}
+
+	/**
+	 * Returns the regulation's consent requirements. Subclasses override.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	abstract protected function consentRequirements(): array;
+
+	/**
+	 * Returns the regulation's data subject rights. Subclasses override.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	abstract protected function dataRights(): array;
+
+	/**
+	 * Returns the regulation's retention rules. Subclasses override.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	abstract protected function retentionRules(): array;
+
+	/**
+	 * Returns the default response-day map keyed by request type, plus an
+	 * optional `default` fallback. Subclasses override.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, int>
+	 */
+	abstract protected function defaultResponseDays(): array;
+
+	/**
+	 * Returns true when the regulation is enabled in configuration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	protected function isEnabled(): bool
+	{
+		return (bool) config( "artisanpack.privacy.regulations.{$this->key}.enabled", false );
+	}
+
+	/**
+	 * Returns the configured `applies_to` region list, uppercased.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	protected function regions(): array
+	{
+		$regions = (array) config( "artisanpack.privacy.regulations.{$this->key}.applies_to", [] );
+
+		return array_map( static fn ( $region ): string => strtoupper( (string) $region ), $regions );
+	}
+
+	/**
+	 * Resolves the visitor's region from the most-trusted source available.
+	 *
+	 * Order:
+	 *  1. `privacy_region` request attribute (set by upstream middleware).
+	 *  2. `X-Region` header (commonly populated by CDNs).
+	 *  3. `geolocation.fallback_region` config value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request  Incoming request.
+	 *
+	 * @return string|null
+	 */
+	protected function resolveRegion( Request $request ): ?string
+	{
+		$attribute = $request->attributes->get( 'privacy_region' );
+
+		if ( is_string( $attribute ) && '' !== $attribute ) {
+			return $attribute;
+		}
+
+		$header = $request->headers->get( 'X-Region' );
+
+		if ( is_string( $header ) && '' !== $header ) {
+			return $header;
+		}
+
+		$fallback = config( 'artisanpack.privacy.geolocation.fallback_region' );
+
+		return is_string( $fallback ) && '' !== $fallback ? $fallback : null;
+	}
+}

--- a/src/Regulations/BaseRegulation.php
+++ b/src/Regulations/BaseRegulation.php
@@ -107,12 +107,23 @@ abstract class BaseRegulation implements PrivacyRegulation
 
 	/**
 	 * @inheritDoc
+	 *
+	 * Configuration may be stored either as a scalar (a single deadline that
+	 * applies to every request type) or as a per-type array — both shapes
+	 * are accepted so applications can model regulations that differentiate
+	 * access vs. deletion timeframes without breaking the scalar default.
 	 */
 	public function getResponseDays( string $requestType ): int
 	{
 		$configured = config( "artisanpack.privacy.data_requests.response_days.{$this->key}" );
 
-		if ( null !== $configured ) {
+		if ( is_array( $configured ) ) {
+			$candidate = $configured[ $requestType ] ?? $configured['default'] ?? null;
+
+			if ( null !== $candidate ) {
+				return (int) $candidate;
+			}
+		} elseif ( null !== $configured ) {
 			return (int) $configured;
 		}
 

--- a/src/Regulations/GenericRegulation.php
+++ b/src/Regulations/GenericRegulation.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * GenericRegulation — config-only regulation fallback.
+ *
+ * Used by the registry when an application enables a regulation key
+ * (`lgpd`, `pipeda`) without supplying a dedicated subclass. Pulls every
+ * answer from configuration so applications can model lightweight
+ * jurisdictions without writing a new class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Regulations;
+
+/**
+ * Config-driven regulation used as a fallback when no dedicated subclass
+ * is registered for a given key.
+ *
+ * Reads its display name, consent requirements, data rights, retention
+ * rules, breach window, and response deadlines from
+ * `regulations.{key}.regulation.*` (or falls back to sensible defaults).
+ *
+ * @since 1.0.0
+ */
+class GenericRegulation extends BaseRegulation
+{
+	/**
+	 * @param  string  $key  Regulation key (e.g. `lgpd`).
+	 * @param  string  $name Display name (defaults to the upper-cased key).
+	 */
+	public function __construct( string $key, string $name = '' )
+	{
+		$this->key  = $key;
+		$this->name = '' === $name ? strtoupper( $key ) : $name;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function consentRequirements(): array
+	{
+		return (array) config( "artisanpack.privacy.regulations.{$this->key}.regulation.consent_requirements", [] );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function dataRights(): array
+	{
+		return (array) config(
+			"artisanpack.privacy.regulations.{$this->key}.regulation.data_rights",
+			[ 'access', 'export', 'deletion', 'rectification' ],
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function retentionRules(): array
+	{
+		return (array) config( "artisanpack.privacy.regulations.{$this->key}.regulation.retention", [] );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function defaultResponseDays(): array
+	{
+		$days = (int) config( 'artisanpack.privacy.data_requests.response_days.default', 30 );
+
+		return [ 'default' => $days ];
+	}
+}

--- a/src/Regulations/RegulationRegistry.php
+++ b/src/Regulations/RegulationRegistry.php
@@ -93,6 +93,20 @@ class RegulationRegistry
 	 */
 	public function get( string $key ): ?PrivacyRegulation
 	{
+		$regulations = (array) config( 'artisanpack.privacy.regulations', [] );
+
+		// Mirror `all()`'s enabled filter so callers cannot end up holding a
+		// disabled regulation through `get()` — every other resolution path
+		// (helpers, `applicableFor()`, the dashboard) treats disabled
+		// regulations as absent, and divergence here causes silent drift.
+		if ( ! array_key_exists( $key, $regulations ) ) {
+			return null;
+		}
+
+		if ( true !== ( $regulations[ $key ]['enabled'] ?? false ) ) {
+			return null;
+		}
+
 		if ( isset( $this->instances[ $key ] ) ) {
 			return $this->instances[ $key ];
 		}
@@ -103,12 +117,6 @@ class RegulationRegistry
 			if ( $instance instanceof PrivacyRegulation ) {
 				return $this->instances[ $key ] = $instance;
 			}
-		}
-
-		$regulations = (array) config( 'artisanpack.privacy.regulations', [] );
-
-		if ( ! array_key_exists( $key, $regulations ) ) {
-			return null;
 		}
 
 		return $this->instances[ $key ] = new GenericRegulation( $key );
@@ -127,10 +135,6 @@ class RegulationRegistry
 		$regulations = (array) config( 'artisanpack.privacy.regulations', [] );
 
 		foreach ( array_keys( $regulations ) as $key ) {
-			if ( true !== ( $regulations[ $key ]['enabled'] ?? false ) ) {
-				continue;
-			}
-
 			$instance = $this->get( (string) $key );
 
 			if ( $instance instanceof PrivacyRegulation ) {
@@ -189,6 +193,36 @@ class RegulationRegistry
 		$matches = $this->applicable( $request );
 
 		return $matches[0] ?? null;
+	}
+
+	/**
+	 * Returns the regulation key the package should record on persisted
+	 * artifacts (consents, data-requests) for the current request.
+	 *
+	 * Resolves through {@see applicableFor()} first so explicit region
+	 * signals win; falls back to the first enabled regulation in config
+	 * order so callers running outside an HTTP request (queues, CLI) still
+	 * get a sensible default instead of null.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request|null  $request  Request to evaluate, when one is available.
+	 *
+	 * @return string|null
+	 */
+	public function currentKey( ?Request $request = null ): ?string
+	{
+		$matched = $this->applicableFor( $request );
+
+		if ( null !== $matched ) {
+			return $matched->key();
+		}
+
+		foreach ( $this->all() as $key => $_ ) {
+			return $key;
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Regulations/RegulationRegistry.php
+++ b/src/Regulations/RegulationRegistry.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * RegulationRegistry — application-wide directory of privacy regulations.
+ *
+ * Resolves regulation instances by key, lets applications register custom
+ * implementations, and answers "which regulations apply to this request?".
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Regulations;
+
+use ArtisanPackUI\Privacy\Contracts\PrivacyRegulation;
+use Illuminate\Http\Request;
+
+/**
+ * Per-application registry of regulation implementations.
+ *
+ * Held as a singleton in the container; rebound with custom instances by
+ * application code that ships its own regulation class.
+ *
+ * @since 1.0.0
+ */
+class RegulationRegistry
+{
+	/**
+	 * Resolved instances keyed by stable regulation key.
+	 *
+	 * @var array<string, PrivacyRegulation>
+	 */
+	protected array $instances = [];
+
+	/**
+	 * Class-name overrides keyed by stable regulation key. Used to inject
+	 * dedicated subclasses (`GdprRegulation`, `CcpaRegulation`, …) before
+	 * any instance has been resolved.
+	 *
+	 * @var array<string, class-string<PrivacyRegulation>>
+	 */
+	protected array $classMap = [];
+
+	/**
+	 * Registers a regulation instance under the supplied key. Replaces any
+	 * existing instance for that key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PrivacyRegulation  $regulation Regulation to register.
+	 *
+	 * @return void
+	 */
+	public function register( PrivacyRegulation $regulation ): void
+	{
+		$this->instances[ $regulation->key() ] = $regulation;
+	}
+
+	/**
+	 * Registers a regulation class to be lazily instantiated when its key is
+	 * first requested.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string                              $key   Regulation key.
+	 * @param  class-string<PrivacyRegulation>     $class Concrete class name.
+	 *
+	 * @return void
+	 */
+	public function registerClass( string $key, string $class ): void
+	{
+		$this->classMap[ $key ] = $class;
+		unset( $this->instances[ $key ] );
+	}
+
+	/**
+	 * Returns the regulation instance for the supplied key, instantiating a
+	 * config-driven fallback when no dedicated class is registered.
+	 *
+	 * Returns null when the key is not present in `regulations.*` at all.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $key Regulation key.
+	 *
+	 * @return PrivacyRegulation|null
+	 */
+	public function get( string $key ): ?PrivacyRegulation
+	{
+		if ( isset( $this->instances[ $key ] ) ) {
+			return $this->instances[ $key ];
+		}
+
+		if ( isset( $this->classMap[ $key ] ) ) {
+			$instance = app( $this->classMap[ $key ] );
+
+			if ( $instance instanceof PrivacyRegulation ) {
+				return $this->instances[ $key ] = $instance;
+			}
+		}
+
+		$regulations = (array) config( 'artisanpack.privacy.regulations', [] );
+
+		if ( ! array_key_exists( $key, $regulations ) ) {
+			return null;
+		}
+
+		return $this->instances[ $key ] = new GenericRegulation( $key );
+	}
+
+	/**
+	 * Returns every enabled regulation keyed by stable identifier.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, PrivacyRegulation>
+	 */
+	public function all(): array
+	{
+		$out         = [];
+		$regulations = (array) config( 'artisanpack.privacy.regulations', [] );
+
+		foreach ( array_keys( $regulations ) as $key ) {
+			if ( true !== ( $regulations[ $key ]['enabled'] ?? false ) ) {
+				continue;
+			}
+
+			$instance = $this->get( (string) $key );
+
+			if ( $instance instanceof PrivacyRegulation ) {
+				$out[ (string) $key ] = $instance;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Returns every regulation that applies to the supplied request — a
+	 * visitor may be subject to several (e.g. an EU resident in California).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 *
+	 * @return array<int, PrivacyRegulation>
+	 */
+	public function applicable( Request $request ): array
+	{
+		$matches = [];
+
+		foreach ( $this->all() as $regulation ) {
+			if ( $regulation->applies( $request ) ) {
+				$matches[] = $regulation;
+			}
+		}
+
+		return $matches;
+	}
+
+	/**
+	 * Returns the single highest-priority regulation for the supplied
+	 * request, or null when none apply.
+	 *
+	 * Priority follows the order keys appear in `regulations.*` — applications
+	 * that need a different precedence can reorder the config or rebind the
+	 * registry with a custom implementation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request|null  $request  Request to evaluate. Defaults to the current request.
+	 *
+	 * @return PrivacyRegulation|null
+	 */
+	public function applicableFor( ?Request $request = null ): ?PrivacyRegulation
+	{
+		$request ??= request();
+
+		if ( ! $request instanceof Request ) {
+			return null;
+		}
+
+		$matches = $this->applicable( $request );
+
+		return $matches[0] ?? null;
+	}
+
+	/**
+	 * Forgets every cached instance and class-map binding. Test-only helper.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function flush(): void
+	{
+		$this->instances = [];
+		$this->classMap  = [];
+	}
+}

--- a/src/Services/ConsentService.php
+++ b/src/Services/ConsentService.php
@@ -429,28 +429,13 @@ class ConsentService
 	 */
 	public function getApplicableRegulation(): ?string
 	{
-		$regulations = (array) config( 'artisanpack.privacy.regulations', [] );
-		$region      = config( 'artisanpack.privacy.geolocation.fallback_region' );
-
-		if ( null !== $region ) {
-			foreach ( $regulations as $key => $config ) {
-				if ( ! ( $config['enabled'] ?? false ) ) {
-					continue;
-				}
-
-				if ( in_array( $region, (array) ( $config['applies_to'] ?? [] ), true ) ) {
-					return (string) $key;
-				}
-			}
-		}
-
-		foreach ( $regulations as $key => $config ) {
-			if ( $config['enabled'] ?? false ) {
-				return (string) $key;
-			}
-		}
-
-		return null;
+		// Delegate to the regulation registry so consent rows, data requests,
+		// and the user-facing dashboard all agree on the same key for any
+		// given request. The registry's `currentKey()` already implements the
+		// region-match-then-first-enabled fallback this method used to do
+		// inline, so callers in console contexts (where no request signals
+		// are available) still get a sensible default.
+		return app( \ArtisanPackUI\Privacy\Regulations\RegulationRegistry::class )->currentKey();
 	}
 
 	/**

--- a/src/Services/PersonalDataScanner.php
+++ b/src/Services/PersonalDataScanner.php
@@ -1,0 +1,541 @@
+<?php
+
+/**
+ * PersonalDataScanner — discovers personal-data fields across Eloquent models.
+ *
+ * Walks the application's models, matches column names against configured
+ * patterns, and produces a per-model inventory the package can persist for
+ * audits and downstream services.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Services;
+
+use ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+use ArtisanPackUI\Privacy\Models\PersonalDataMap;
+use FilesystemIterator;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use SplFileInfo;
+use Throwable;
+
+/**
+ * Personal data discovery service.
+ *
+ * @since 1.0.0
+ */
+class PersonalDataScanner
+{
+	public const SOURCE_TRAIT   = 'trait';
+	public const SOURCE_PATTERN = 'pattern';
+
+	/**
+	 * High-sensitivity field types. Any match against one of these types is
+	 * promoted to {@see PersonalDataMap::SENSITIVITY_SENSITIVE}.
+	 *
+	 * @var array<int, string>
+	 */
+	protected array $sensitiveTypes = [ 'ssn', 'tax_id', 'health', 'financial' ];
+
+	/**
+	 * Scans every model the configured paths expose and returns the merged
+	 * field map keyed by fully-qualified model class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<class-string<Model>, array<string, array<string, mixed>>>
+	 */
+	public function scan(): array
+	{
+		$results = [];
+
+		foreach ( $this->discoverModelClasses() as $class ) {
+			$fields = $this->scanModel( $class );
+
+			if ( [] !== $fields ) {
+				$results[ $class ] = $fields;
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Scans a single model and returns its field map.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  class-string<Model>  $modelClass Fully-qualified model class.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function scanModel( string $modelClass ): array
+	{
+		if ( ! $this->isScannableModel( $modelClass ) ) {
+			return [];
+		}
+
+		try {
+			/** @var Model $model */
+			$model = new $modelClass();
+		} catch ( Throwable ) {
+			return [];
+		}
+
+		$traitFields   = $this->collectTraitDeclaredFields( $model );
+		$patternFields = $this->collectPatternMatchedFields( $model, array_keys( $traitFields ) );
+
+		return $traitFields + $patternFields;
+	}
+
+	/**
+	 * Persists a single field mapping. Updates existing rows in place so the
+	 * scanner can be re-run without producing duplicates.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string                $model  Fully-qualified model class.
+	 * @param  string                $field  Column name.
+	 * @param  array<string, mixed>  $config Field configuration (type, sensitivity, …).
+	 *
+	 * @return PersonalDataMap
+	 */
+	public function registerField( string $model, string $field, array $config = [] ): PersonalDataMap
+	{
+		$payload = [
+			'data_type'         => (string) ( $config['data_type'] ?? $config['type'] ?? 'unknown' ),
+			'sensitivity'       => (string) ( $config['sensitivity'] ?? PersonalDataMap::SENSITIVITY_NORMAL ),
+			'retention_period'  => $config['retention_period'] ?? null,
+			'deletion_strategy' => (string) ( $config['deletion_strategy'] ?? PersonalDataMap::STRATEGY_ANONYMIZE ),
+			'export_format'     => $config['export_format'] ?? null,
+			'auto_discovered'   => (bool) ( $config['auto_discovered'] ?? false ),
+		];
+
+		return PersonalDataMap::query()->updateOrCreate(
+			[ 'model' => $model, 'field' => $field ],
+			$payload,
+		);
+	}
+
+	/**
+	 * Returns the persisted field mappings for a single model, keyed by
+	 * column name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  class-string<Model>  $modelClass Fully-qualified model class.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getFieldMappings( string $modelClass ): array
+	{
+		return PersonalDataMap::query()
+			->forModel( $modelClass )
+			->get()
+			->keyBy( 'field' )
+			->map( static fn ( PersonalDataMap $map ): array => [
+				'data_type'         => $map->data_type,
+				'sensitivity'       => $map->sensitivity,
+				'retention_period'  => $map->retention_period,
+				'deletion_strategy' => $map->deletion_strategy,
+				'export_format'     => $map->export_format,
+				'auto_discovered'   => (bool) $map->auto_discovered,
+			] )
+			->all();
+	}
+
+	/**
+	 * Returns a flattened data inventory suitable for serialization (DPO
+	 * reports, audit handoffs, …).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function generateDataInventory(): array
+	{
+		$discovered = $this->scan();
+		$inventory  = [];
+
+		foreach ( $discovered as $modelClass => $fields ) {
+			foreach ( $fields as $field => $config ) {
+				$inventory[] = array_merge(
+					[
+						'model' => $modelClass,
+						'field' => $field,
+					],
+					$config,
+				);
+			}
+		}
+
+		foreach ( PersonalDataMap::query()->get() as $row ) {
+			$key = $row->model . '::' . $row->field;
+
+			foreach ( $inventory as $entry ) {
+				if ( $entry['model'] . '::' . $entry['field'] === $key ) {
+					continue 2;
+				}
+			}
+
+			$inventory[] = [
+				'model'             => $row->model,
+				'field'             => $row->field,
+				'data_type'         => $row->data_type,
+				'sensitivity'       => $row->sensitivity,
+				'retention_period'  => $row->retention_period,
+				'deletion_strategy' => $row->deletion_strategy,
+				'export_format'     => $row->export_format,
+				'auto_discovered'   => (bool) $row->auto_discovered,
+				'source'            => 'persisted',
+			];
+		}
+
+		return $inventory;
+	}
+
+	/**
+	 * Merges the supplied scan results into the persisted map table. Returns
+	 * the number of rows written.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<class-string<Model>, array<string, array<string, mixed>>>  $scanResults Map produced by {@see scan()}.
+	 *
+	 * @return int
+	 */
+	public function persist( array $scanResults ): int
+	{
+		$written = 0;
+
+		foreach ( $scanResults as $modelClass => $fields ) {
+			foreach ( $fields as $field => $config ) {
+				$this->registerField( $modelClass, $field, $config );
+				$written++;
+			}
+		}
+
+		return $written;
+	}
+
+	/**
+	 * Returns the configured field-pattern map keyed by data type.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	protected function fieldPatterns(): array
+	{
+		return (array) config( 'artisanpack.privacy.discovery.field_patterns', [] );
+	}
+
+	/**
+	 * Returns the list of configured scan paths.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	protected function scanPaths(): array
+	{
+		return (array) config( 'artisanpack.privacy.discovery.scan_paths', [] );
+	}
+
+	/**
+	 * Returns the list of excluded model class names.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, class-string>
+	 */
+	protected function excludedModels(): array
+	{
+		return (array) config( 'artisanpack.privacy.discovery.exclude_models', [] );
+	}
+
+	/**
+	 * Discovers candidate model classes by reflecting over the configured
+	 * scan paths.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, class-string<Model>>
+	 */
+	protected function discoverModelClasses(): array
+	{
+		$found = [];
+
+		foreach ( $this->scanPaths() as $path ) {
+			if ( ! is_dir( (string) $path ) ) {
+				continue;
+			}
+
+			foreach ( $this->iterateDirectory( (string) $path ) as $file ) {
+				$class = $this->classFromFile( $file );
+
+				if ( null === $class ) {
+					continue;
+				}
+
+				if ( ! $this->isScannableModel( $class ) ) {
+					continue;
+				}
+
+				$found[ $class ] = $class;
+			}
+		}
+
+		return array_values( $found );
+	}
+
+	/**
+	 * Yields the `*.php` files inside the supplied directory recursively.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $path Directory to walk.
+	 *
+	 * @return iterable<int, string>
+	 */
+	protected function iterateDirectory( string $path ): iterable
+	{
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		);
+
+		foreach ( $iterator as $file ) {
+			if ( ! $file instanceof SplFileInfo || 'php' !== strtolower( $file->getExtension() ) ) {
+				continue;
+			}
+
+			yield $file->getPathname();
+		}
+	}
+
+	/**
+	 * Attempts to resolve a fully-qualified class name from a PHP file by
+	 * parsing its namespace declaration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $file Absolute path to a PHP file.
+	 *
+	 * @return class-string|null
+	 */
+	protected function classFromFile( string $file ): ?string
+	{
+		$contents = @file_get_contents( $file );
+
+		if ( false === $contents ) {
+			return null;
+		}
+
+		if ( ! preg_match( '/^namespace\s+([^;]+);/m', $contents, $matches ) ) {
+			return null;
+		}
+
+		$namespace = trim( $matches[1] );
+		$class     = pathinfo( $file, PATHINFO_FILENAME );
+
+		return $namespace . '\\' . $class;
+	}
+
+	/**
+	 * Returns true when the supplied class is a concrete Eloquent model that
+	 * the scanner should inspect.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $class Fully-qualified class name.
+	 *
+	 * @return bool
+	 */
+	protected function isScannableModel( string $class ): bool
+	{
+		if ( in_array( $class, $this->excludedModels(), true ) ) {
+			return false;
+		}
+
+		if ( ! class_exists( $class ) ) {
+			return false;
+		}
+
+		try {
+			$reflection = new ReflectionClass( $class );
+		} catch ( Throwable ) {
+			return false;
+		}
+
+		if ( $reflection->isAbstract() ) {
+			return false;
+		}
+
+		return $reflection->isSubclassOf( Model::class );
+	}
+
+	/**
+	 * Collects the fields a model declares through the
+	 * {@see HasPersonalData} trait.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $model Model instance to inspect.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function collectTraitDeclaredFields( Model $model ): array
+	{
+		if ( ! in_array( HasPersonalData::class, class_uses_recursive( $model ), true ) ) {
+			return [];
+		}
+
+		$declared = [];
+
+		foreach ( $model->personalDataFields() as $key => $value ) {
+			$field    = is_string( $key ) ? $key : (string) $value;
+			$metadata = is_array( $value ) ? $value : [];
+
+			$type        = (string) ( $metadata['type'] ?? $this->guessTypeFromName( $field ) ?? 'unknown' );
+			$sensitivity = (string) ( $metadata['sensitivity'] ?? $this->sensitivityFor( $type ) );
+			$strategy    = (string) ( $metadata['deletion_strategy'] ?? PersonalDataMap::STRATEGY_ANONYMIZE );
+
+			$declared[ $field ] = [
+				'data_type'         => $type,
+				'sensitivity'       => $sensitivity,
+				'deletion_strategy' => $strategy,
+				'retention_period'  => $metadata['retention_period'] ?? null,
+				'export_format'     => $metadata['export_format'] ?? null,
+				'auto_discovered'   => false,
+				'source'            => self::SOURCE_TRAIT,
+			];
+		}
+
+		return $declared;
+	}
+
+	/**
+	 * Matches the model's columns against the configured patterns to
+	 * discover personal-data fields that were not declared explicitly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model              $model    Model instance to inspect.
+	 * @param  array<int, string> $declared Field names already covered by the trait scan.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function collectPatternMatchedFields( Model $model, array $declared ): array
+	{
+		$columns = $this->modelColumns( $model );
+		$matches = [];
+
+		foreach ( $columns as $column ) {
+			if ( in_array( $column, $declared, true ) ) {
+				continue;
+			}
+
+			$type = $this->guessTypeFromName( $column );
+
+			if ( null === $type ) {
+				continue;
+			}
+
+			$matches[ $column ] = [
+				'data_type'         => $type,
+				'sensitivity'       => $this->sensitivityFor( $type ),
+				'deletion_strategy' => PersonalDataMap::STRATEGY_ANONYMIZE,
+				'retention_period'  => null,
+				'export_format'     => null,
+				'auto_discovered'   => true,
+				'source'            => self::SOURCE_PATTERN,
+			];
+		}
+
+		return $matches;
+	}
+
+	/**
+	 * Returns the column list for a model — uses the schema builder when a
+	 * database connection is available, otherwise falls back to the model's
+	 * `fillable` attribute.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model  $model Model instance to inspect.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function modelColumns( Model $model ): array
+	{
+		try {
+			return Schema::connection( $model->getConnectionName() )
+				->getColumnListing( $model->getTable() );
+		} catch ( Throwable ) {
+			return $model->getFillable();
+		}
+	}
+
+	/**
+	 * Best-effort type guess from a column name using the configured pattern
+	 * map.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $field Column name.
+	 *
+	 * @return string|null
+	 */
+	protected function guessTypeFromName( string $field ): ?string
+	{
+		$lower = Str::lower( $field );
+
+		foreach ( $this->fieldPatterns() as $type => $patterns ) {
+			foreach ( (array) $patterns as $pattern ) {
+				if ( $lower === Str::lower( (string) $pattern ) ) {
+					return (string) $type;
+				}
+			}
+		}
+
+		foreach ( $this->fieldPatterns() as $type => $patterns ) {
+			foreach ( (array) $patterns as $pattern ) {
+				$needle = Str::lower( (string) $pattern );
+
+				if ( '' !== $needle && Str::contains( $lower, $needle ) ) {
+					return (string) $type;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the canonical sensitivity classification for a data type.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $type Data type.
+	 *
+	 * @return string
+	 */
+	protected function sensitivityFor( string $type ): string
+	{
+		return in_array( $type, $this->sensitiveTypes, true )
+			? PersonalDataMap::SENSITIVITY_SENSITIVE
+			: PersonalDataMap::SENSITIVITY_NORMAL;
+	}
+}

--- a/src/Services/PersonalDataScanner.php
+++ b/src/Services/PersonalDataScanner.php
@@ -168,10 +168,13 @@ class PersonalDataScanner
 	{
 		$discovered = $this->scan();
 		$inventory  = [];
+		$seen       = [];
 
 		foreach ( $discovered as $modelClass => $fields ) {
 			foreach ( $fields as $field => $config ) {
-				$inventory[] = array_merge(
+				$key          = $modelClass . '::' . $field;
+				$seen[ $key ] = true;
+				$inventory[]  = array_merge(
 					[
 						'model' => $modelClass,
 						'field' => $field,
@@ -184,10 +187,8 @@ class PersonalDataScanner
 		foreach ( PersonalDataMap::query()->get() as $row ) {
 			$key = $row->model . '::' . $row->field;
 
-			foreach ( $inventory as $entry ) {
-				if ( $entry['model'] . '::' . $entry['field'] === $key ) {
-					continue 2;
-				}
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
 			}
 
 			$inventory[] = [
@@ -500,7 +501,8 @@ class PersonalDataScanner
 	 */
 	protected function guessTypeFromName( string $field ): ?string
 	{
-		$lower = Str::lower( $field );
+		$lower  = Str::lower( $field );
+		$tokens = $this->tokenize( $lower );
 
 		foreach ( $this->fieldPatterns() as $type => $patterns ) {
 			foreach ( (array) $patterns as $pattern ) {
@@ -510,17 +512,87 @@ class PersonalDataScanner
 			}
 		}
 
+		// Token-level match avoids the unanchored-substring trap where
+		// `username` collides with the `name` pattern or `tenant_id` collides
+		// with the `id` pattern. Compare against the column's underscore /
+		// dash / camelCase tokens instead of a raw string contains.
 		foreach ( $this->fieldPatterns() as $type => $patterns ) {
 			foreach ( (array) $patterns as $pattern ) {
 				$needle = Str::lower( (string) $pattern );
 
-				if ( '' !== $needle && Str::contains( $lower, $needle ) ) {
+				if ( '' === $needle ) {
+					continue;
+				}
+
+				$patternTokens = $this->tokenize( $needle );
+
+				if ( $this->tokensContainSequence( $tokens, $patternTokens ) ) {
 					return (string) $type;
 				}
 			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * Splits a column name into lowercase tokens on underscores, dashes, and
+	 * camelCase boundaries.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $value Identifier to split.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function tokenize( string $value ): array
+	{
+		$withSpaces = (string) preg_replace( '/([a-z0-9])([A-Z])/', '$1 $2', $value );
+		$normalized = strtolower( str_replace( [ '_', '-' ], ' ', $withSpaces ) );
+
+		return array_values( array_filter(
+			preg_split( '/\s+/', $normalized ) ?: [],
+			static fn ( string $token ): bool => '' !== $token,
+		) );
+	}
+
+	/**
+	 * Returns true when `$needle` appears as a contiguous sequence inside
+	 * `$haystack`. Both arrays are pre-tokenized.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, string>  $haystack Tokens to search.
+	 * @param  array<int, string>  $needle   Tokens to find.
+	 *
+	 * @return bool
+	 */
+	protected function tokensContainSequence( array $haystack, array $needle ): bool
+	{
+		$needleLength = count( $needle );
+
+		if ( 0 === $needleLength ) {
+			return false;
+		}
+
+		$haystackLength = count( $haystack );
+
+		for ( $i = 0; $i <= $haystackLength - $needleLength; ++$i ) {
+			$match = true;
+
+			for ( $j = 0; $j < $needleLength; ++$j ) {
+				if ( $haystack[ $i + $j ] !== $needle[ $j ] ) {
+					$match = false;
+					break;
+				}
+			}
+
+			if ( $match ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Traits/HasPersonalData.php
+++ b/src/Traits/HasPersonalData.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * HasPersonalData trait — alias namespace.
+ *
+ * The canonical implementation lives at
+ * {@see \ArtisanPackUI\Privacy\Concerns\HasPersonalData} (the Laravel-style
+ * namespace). This alias is provided so applications following the more
+ * generic `App\Traits\…` convention can `use ArtisanPackUI\Privacy\Traits\HasPersonalData`
+ * without having to think about the Concerns alternative.
+ *
+ * The package's services still check for the canonical trait via
+ * `class_uses_recursive()`, so consumers may import either namespace —
+ * both register the same underlying trait.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Traits;
+
+use ArtisanPackUI\Privacy\Concerns\HasPersonalData as CanonicalHasPersonalData;
+
+trait HasPersonalData
+{
+	use CanonicalHasPersonalData;
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,12 +14,15 @@
  * @since      1.0.0
  */
 
+use ArtisanPackUI\Privacy\Contracts\PrivacyRegulation;
 use ArtisanPackUI\Privacy\Models\DataRequest;
 use ArtisanPackUI\Privacy\Privacy;
+use ArtisanPackUI\Privacy\Regulations\RegulationRegistry;
 use ArtisanPackUI\Privacy\Services\AnonymizationService;
 use ArtisanPackUI\Privacy\Services\ConsentService;
 use ArtisanPackUI\Privacy\Services\DataRequestService;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
 
 if ( ! function_exists( 'privacy' ) ) {
 	/**
@@ -64,6 +67,37 @@ if ( ! function_exists( 'privacyGetRegulation' ) ) {
 	function privacyGetRegulation(): ?string
 	{
 		return app( ConsentService::class )->getApplicableRegulation();
+	}
+}
+
+if ( ! function_exists( 'privacyRegulations' ) ) {
+	/**
+	 * Returns the regulation registry.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return RegulationRegistry
+	 */
+	function privacyRegulations(): RegulationRegistry
+	{
+		return app( RegulationRegistry::class );
+	}
+}
+
+if ( ! function_exists( 'getApplicableRegulation' ) ) {
+	/**
+	 * Returns the highest-priority {@see PrivacyRegulation} that applies to
+	 * the supplied (or current) request, or null when none apply.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request|null  $request  Request to evaluate. Defaults to the current request.
+	 *
+	 * @return PrivacyRegulation|null
+	 */
+	function getApplicableRegulation( ?Request $request = null ): ?PrivacyRegulation
+	{
+		return app( RegulationRegistry::class )->applicableFor( $request );
 	}
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -84,10 +84,14 @@ if ( ! function_exists( 'privacyRegulations' ) ) {
 	}
 }
 
-if ( ! function_exists( 'getApplicableRegulation' ) ) {
+if ( ! function_exists( 'privacyApplicableRegulation' ) ) {
 	/**
 	 * Returns the highest-priority {@see PrivacyRegulation} that applies to
 	 * the supplied (or current) request, or null when none apply.
+	 *
+	 * Sibling helpers in this file all use the `privacy*` prefix to avoid
+	 * polluting the global namespace — keep this one consistent so editor
+	 * autocompletion groups them together.
 	 *
 	 * @since 1.0.0
 	 *
@@ -95,7 +99,7 @@ if ( ! function_exists( 'getApplicableRegulation' ) ) {
 	 *
 	 * @return PrivacyRegulation|null
 	 */
-	function getApplicableRegulation( ?Request $request = null ): ?PrivacyRegulation
+	function privacyApplicableRegulation( ?Request $request = null ): ?PrivacyRegulation
 	{
 		return app( RegulationRegistry::class )->applicableFor( $request );
 	}

--- a/tests/Feature/Concerns/HasPersonalDataTest.php
+++ b/tests/Feature/Concerns/HasPersonalDataTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+use ArtisanPackUI\Privacy\Services\AnonymizationService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach( function (): void {
+	Schema::create( 'has_pd_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'email' )->nullable();
+		$table->string( 'name' )->nullable();
+	} );
+
+	if ( ! class_exists( HasPersonalDataModel::class ) ) {
+		eval( <<<'PHP'
+			class HasPersonalDataModel extends \Illuminate\Database\Eloquent\Model
+			{
+				use \ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+
+				public $timestamps = false;
+				protected $table = 'has_pd_subjects';
+				protected $guarded = [];
+
+				public function personalDataFields(): array
+				{
+					return [
+						'email' => [
+							'type'              => 'email',
+							'sensitivity'       => 'normal',
+							'deletion_strategy' => 'anonymize',
+						],
+						'name' => [
+							'type'              => 'name',
+							'sensitivity'       => 'normal',
+							'deletion_strategy' => 'anonymize',
+						],
+					];
+				}
+			}
+		PHP );
+	}
+
+	if ( ! class_exists( HasPersonalDataAliasModel::class ) ) {
+		eval( <<<'PHP'
+			class HasPersonalDataAliasModel extends \Illuminate\Database\Eloquent\Model
+			{
+				use \ArtisanPackUI\Privacy\Traits\HasPersonalData;
+
+				public $timestamps = false;
+				protected $table = 'has_pd_subjects';
+				protected $guarded = [];
+
+				protected $personalDataFields = [ 'email', 'name' ];
+			}
+		PHP );
+	}
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'has_pd_subjects' );
+} );
+
+it( 'returns a flat list of column names regardless of declaration shape', function (): void {
+	$model = new HasPersonalDataModel( [ 'email' => 'a@example.com', 'name' => 'A' ] );
+
+	expect( $model->personalDataFieldNames() )->toBe( [ 'email', 'name' ] );
+} );
+
+it( 'returns per-field metadata when declared as a map', function (): void {
+	$model = new HasPersonalDataModel();
+
+	expect( $model->personalDataFieldMetadata( 'email' )['type'] )->toBe( 'email' );
+	expect( $model->personalDataFieldMetadata( 'email' )['deletion_strategy'] )->toBe( 'anonymize' );
+	expect( $model->personalDataFieldMetadata( 'missing' ) )->toBe( [] );
+} );
+
+it( 'getPersonalData returns a column → value map', function (): void {
+	$model = new HasPersonalDataModel( [ 'email' => 'a@example.com', 'name' => 'A' ] );
+
+	expect( $model->getPersonalData() )->toBe( [
+		'email' => 'a@example.com',
+		'name'  => 'A',
+	] );
+} );
+
+it( 'works through the Traits alias and exposes the same API', function (): void {
+	$model = new HasPersonalDataAliasModel( [ 'email' => 'b@example.com', 'name' => 'B' ] );
+
+	expect( in_array(
+		HasPersonalData::class,
+		class_uses_recursive( $model ),
+		true,
+	) )->toBeTrue();
+
+	expect( $model->getPersonalData() )->toBe( [
+		'email' => 'b@example.com',
+		'name'  => 'B',
+	] );
+} );
+
+it( 'anonymizePersonalData uses the per-field strategy from metadata', function (): void {
+	$model = HasPersonalDataModel::create( [ 'email' => 'pre@example.com', 'name' => 'Pre' ] );
+
+	expect( $model->anonymizePersonalData() )->toBeTrue();
+
+	$model->refresh();
+
+	expect( $model->email )->not->toBe( 'pre@example.com' );
+	expect( $model->name )->not->toBe( 'Pre' );
+} );
+
+it( 'deletePersonalData delegates to the DataDeletionService', function (): void {
+	$model = HasPersonalDataModel::create( [ 'email' => 'pre@example.com', 'name' => 'Pre' ] );
+
+	expect( $model->deletePersonalData() )->toBeTrue();
+
+	$model->refresh();
+
+	expect( $model->email )->not->toBe( 'pre@example.com' );
+} );
+
+it( 'falls back to the anonymization service defaults when no metadata is declared', function (): void {
+	$model = HasPersonalDataAliasModel::create( [ 'email' => 'plain@example.com', 'name' => 'Plain' ] );
+
+	expect( app( AnonymizationService::class ) )->toBeInstanceOf( AnonymizationService::class );
+
+	// The Traits alias model declares fields as a plain list — anonymization
+	// should still work using config defaults from the service.
+	expect( $model->anonymizePersonalData() )->toBeTrue();
+} );

--- a/tests/Feature/Concerns/HasPersonalDataTest.php
+++ b/tests/Feature/Concerns/HasPersonalDataTest.php
@@ -132,3 +132,35 @@ it( 'falls back to the anonymization service defaults when no metadata is declar
 	// should still work using config defaults from the service.
 	expect( $model->anonymizePersonalData() )->toBeTrue();
 } );
+
+it( 'anonymizes declared fields that do not match any discovery pattern', function (): void {
+	Schema::table( 'has_pd_subjects', function ( Blueprint $table ): void {
+		$table->string( 'arbitrary_handle' )->nullable();
+	} );
+
+	if ( ! class_exists( HasPersonalDataNonPatternModel::class ) ) {
+		eval( <<<'PHP'
+			class HasPersonalDataNonPatternModel extends \Illuminate\Database\Eloquent\Model
+			{
+				use \ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+
+				public $timestamps = false;
+				protected $table = 'has_pd_subjects';
+				protected $guarded = [];
+
+				protected $personalDataFields = [ 'arbitrary_handle' ];
+			}
+		PHP );
+	}
+
+	$model = HasPersonalDataNonPatternModel::create( [
+		'arbitrary_handle' => 'original-handle-value',
+	] );
+
+	expect( $model->anonymizePersonalData() )->toBeTrue();
+
+	$model->refresh();
+
+	expect( $model->arbitrary_handle )->not->toBe( 'original-handle-value' );
+	expect( $model->arbitrary_handle )->not->toBeNull();
+} );

--- a/tests/Feature/Console/PrivacyScanTest.php
+++ b/tests/Feature/Console/PrivacyScanTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\PersonalDataMap;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach( function (): void {
+	Schema::create( 'cmd_scan_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'email' )->nullable();
+		$table->string( 'phone' )->nullable();
+	} );
+
+	if ( ! class_exists( CmdScanSubject::class ) ) {
+		eval( <<<'PHP'
+			class CmdScanSubject extends \Illuminate\Database\Eloquent\Model
+			{
+				public $timestamps = false;
+				protected $table = 'cmd_scan_subjects';
+				protected $guarded = [];
+			}
+		PHP );
+	}
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'cmd_scan_subjects' );
+} );
+
+it( 'runs the scanner against a specific model and prints a summary', function (): void {
+	$this->artisan( 'privacy:scan', [ '--model' => CmdScanSubject::class ] )
+		->expectsOutputToContain( CmdScanSubject::class )
+		->expectsOutputToContain( 'email' )
+		->expectsOutputToContain( 'Found 2 personal-data field(s)' )
+		->assertSuccessful();
+} );
+
+it( 'persists discovered mappings when --save is supplied', function (): void {
+	$this->artisan( 'privacy:scan', [ '--model' => CmdScanSubject::class, '--save' => true ] )
+		->assertSuccessful();
+
+	expect( PersonalDataMap::query()->where( 'model', CmdScanSubject::class )->count() )
+		->toBe( 2 );
+} );
+
+it( 'emits valid JSON when --format=json', function (): void {
+	$exitCode = $this->artisan( 'privacy:scan', [
+		'--model'  => CmdScanSubject::class,
+		'--format' => 'json',
+	] )->run();
+
+	expect( $exitCode )->toBe( 0 );
+} );
+
+it( 'rejects unknown formats', function (): void {
+	$this->artisan( 'privacy:scan', [ '--format' => 'yaml' ] )
+		->expectsOutputToContain( 'Unsupported format' )
+		->assertExitCode( 2 );
+} );

--- a/tests/Feature/Console/PrivacyScanTest.php
+++ b/tests/Feature/Console/PrivacyScanTest.php
@@ -59,3 +59,15 @@ it( 'rejects unknown formats', function (): void {
 		->expectsOutputToContain( 'Unsupported format' )
 		->assertExitCode( 2 );
 } );
+
+it( 'rejects non-existent model classes with a clear error', function (): void {
+	$this->artisan( 'privacy:scan', [ '--model' => 'App\\NotAModel' ] )
+		->expectsOutputToContain( 'could not be resolved' )
+		->assertExitCode( 2 );
+} );
+
+it( 'rejects classes that are not Eloquent models', function (): void {
+	$this->artisan( 'privacy:scan', [ '--model' => stdClass::class ] )
+		->expectsOutputToContain( 'could not be resolved' )
+		->assertExitCode( 2 );
+} );

--- a/tests/Feature/Http/DataRequestApiTest.php
+++ b/tests/Feature/Http/DataRequestApiTest.php
@@ -130,3 +130,33 @@ it( 'returns the authenticated subject history with download URLs for completed 
 
 	expect( $pendingPayload['download_url'] )->toBeNull();
 } );
+
+it( 'isolates subjects so user A cannot see user Bs request history', function (): void {
+	$alice = TestSubject::create();
+	$bob   = TestSubject::create();
+
+	DataRequest::query()->create( [
+		'requestable_type' => $alice->getMorphClass(),
+		'requestable_id'   => $alice->getKey(),
+		'type'             => DataRequest::TYPE_EXPORT,
+		'status'           => DataRequest::STATUS_COMPLETED,
+		'data'             => [ 'download_url' => 'https://example.test/alice-export.json' ],
+	] );
+
+	$bobsRequest = DataRequest::query()->create( [
+		'requestable_type' => $bob->getMorphClass(),
+		'requestable_id'   => $bob->getKey(),
+		'type'             => DataRequest::TYPE_ACCESS,
+		'status'           => DataRequest::STATUS_PENDING,
+	] );
+
+	$this->actingAs( $alice );
+	$response = $this->getJson( '/api/privacy/data-requests' );
+
+	$response->assertOk();
+
+	$ids = array_column( $response->json( 'requests' ), 'id' );
+
+	expect( $ids )->not->toContain( $bobsRequest->id );
+	expect( count( $ids ) )->toBe( 1 );
+} );

--- a/tests/Feature/Http/DataRequestApiTest.php
+++ b/tests/Feature/Http/DataRequestApiTest.php
@@ -88,3 +88,45 @@ it( 'accepts a missing reason', function (): void {
 		'type' => DataRequest::TYPE_EXPORT,
 	] )->assertCreated();
 } );
+
+it( 'returns 401 when an unauthenticated visitor requests their history', function (): void {
+	$this->getJson( '/api/privacy/data-requests' )->assertUnauthorized();
+} );
+
+it( 'returns the authenticated subject history with download URLs for completed exports', function (): void {
+	$subject = TestSubject::create();
+	$this->actingAs( $subject );
+
+	$export = DataRequest::query()->create( [
+		'requestable_type' => $subject->getMorphClass(),
+		'requestable_id'   => $subject->getKey(),
+		'type'             => DataRequest::TYPE_EXPORT,
+		'status'           => DataRequest::STATUS_COMPLETED,
+		'data'             => [ 'download_url' => 'https://example.test/export.json' ],
+	] );
+
+	$pending = DataRequest::query()->create( [
+		'requestable_type' => $subject->getMorphClass(),
+		'requestable_id'   => $subject->getKey(),
+		'type'             => DataRequest::TYPE_ACCESS,
+		'status'           => DataRequest::STATUS_PENDING,
+	] );
+
+	$response = $this->getJson( '/api/privacy/data-requests?limit=10' );
+
+	$response->assertOk();
+	$response->assertJsonCount( 2, 'requests' );
+
+	$payload = $response->json();
+	$ids     = array_column( $payload['requests'], 'id' );
+
+	expect( $ids )->toContain( $export->id, $pending->id );
+
+	$exportPayload = collect( $payload['requests'] )->firstWhere( 'id', $export->id );
+
+	expect( $exportPayload['download_url'] )->toBe( 'https://example.test/export.json' );
+
+	$pendingPayload = collect( $payload['requests'] )->firstWhere( 'id', $pending->id );
+
+	expect( $pendingPayload['download_url'] )->toBeNull();
+} );

--- a/tests/Feature/Livewire/PrivacyDashboardTest.php
+++ b/tests/Feature/Livewire/PrivacyDashboardTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Livewire\PrivacyDashboard;
+use ArtisanPackUI\Privacy\Models\DataRequest;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+use Tests\Support\TestSubject;
+
+beforeEach( function (): void {
+	if ( ! class_exists( Livewire::class ) ) {
+		$this->markTestSkipped( 'Livewire is not installed.' );
+	}
+
+	Schema::create( 'test_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'name' )->nullable();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'test_subjects' );
+} );
+
+it( 'renders a sign-in prompt for guests', function (): void {
+	Livewire::test( PrivacyDashboard::class )
+		->assertSee( __( 'Please sign in to view your privacy dashboard.' ) );
+} );
+
+it( 'lists the authenticated subjects request history', function (): void {
+	$subject = TestSubject::create();
+	$this->actingAs( $subject );
+
+	$request = DataRequest::query()->create( [
+		'requestable_type' => $subject->getMorphClass(),
+		'requestable_id'   => $subject->getKey(),
+		'type'             => DataRequest::TYPE_EXPORT,
+		'status'           => DataRequest::STATUS_COMPLETED,
+		'data'             => [ 'download_url' => 'https://example.test/export.json' ],
+	] );
+
+	Livewire::test( PrivacyDashboard::class )
+		->assertSee( __( 'Request history' ) )
+		->assertSee( ucfirst( DataRequest::TYPE_EXPORT ) )
+		->assertSee( __( 'Download export' ) );
+
+	expect( $request->fresh()->data['download_url'] )->toBe( 'https://example.test/export.json' );
+} );
+
+it( 'bumps the history version when a request is submitted by the embedded form', function (): void {
+	$subject = TestSubject::create();
+	$this->actingAs( $subject );
+
+	Livewire::test( PrivacyDashboard::class )
+		->dispatch( 'privacy:data-request-submitted', id: 1, type: 'access' )
+		->assertSet( 'requestsVersion', 1 );
+} );
+
+it( 'honours the showHistory toggle when set to false on mount', function (): void {
+	$subject = TestSubject::create();
+	$this->actingAs( $subject );
+
+	Livewire::test( PrivacyDashboard::class, [ 'showHistory' => false ] )
+		->assertDontSee( __( 'Request history' ) );
+} );
+
+it( 'renders the policy link when a URL is supplied', function (): void {
+	$subject = TestSubject::create();
+	$this->actingAs( $subject );
+
+	Livewire::test( PrivacyDashboard::class, [ 'policyUrl' => 'https://example.test/policy' ] )
+		->assertSee( 'https://example.test/policy' );
+} );

--- a/tests/Feature/Regulations/RegulationRegistryTest.php
+++ b/tests/Feature/Regulations/RegulationRegistryTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Contracts\PrivacyRegulation;
+use ArtisanPackUI\Privacy\Regulations\BaseRegulation;
+use ArtisanPackUI\Privacy\Regulations\GenericRegulation;
+use ArtisanPackUI\Privacy\Regulations\RegulationRegistry;
+use Illuminate\Http\Request;
+
+beforeEach( function (): void {
+	config()->set( 'artisanpack.privacy.regulations', [
+		'gdpr' => [
+			'enabled'                   => true,
+			'applies_to'                => [ 'EU', 'UK' ],
+			'consent_expiry_days'       => 365,
+			'breach_notification_hours' => 72,
+		],
+		'ccpa' => [
+			'enabled'    => true,
+			'applies_to' => [ 'US-CA' ],
+		],
+		'lgpd' => [
+			'enabled'    => false,
+			'applies_to' => [ 'BR' ],
+		],
+	] );
+	config()->set( 'artisanpack.privacy.geolocation.fallback_region', null );
+	config()->set( 'artisanpack.privacy.data_requests.response_days', [
+		'gdpr'    => 30,
+		'ccpa'    => 45,
+		'default' => 30,
+	] );
+
+	app( RegulationRegistry::class )->flush();
+} );
+
+it( 'returns a config-driven generic regulation for known keys', function (): void {
+	$registry = app( RegulationRegistry::class );
+
+	$regulation = $registry->get( 'gdpr' );
+
+	expect( $regulation )->toBeInstanceOf( GenericRegulation::class );
+	expect( $regulation->key() )->toBe( 'gdpr' );
+	expect( $regulation->getBreachNotificationHours() )->toBe( 72 );
+	expect( $regulation->getResponseDays( 'access' ) )->toBe( 30 );
+} );
+
+it( 'returns null for keys that are not configured', function (): void {
+	expect( app( RegulationRegistry::class )->get( 'pdpa' ) )->toBeNull();
+} );
+
+it( 'lets applications register a custom regulation class', function (): void {
+	$registry = app( RegulationRegistry::class );
+
+	$registry->register( new class extends BaseRegulation {
+		protected string $key  = 'gdpr';
+
+		protected string $name = 'GDPR (custom)';
+
+		protected function consentRequirements(): array
+		{
+			return [ 'explicit_opt_in' => true ];
+		}
+
+		protected function dataRights(): array
+		{
+			return [ 'access', 'erasure', 'portability' ];
+		}
+
+		protected function retentionRules(): array
+		{
+			return [ 'consent' => 365 ];
+		}
+
+		protected function defaultResponseDays(): array
+		{
+			return [ 'default' => 30 ];
+		}
+	} );
+
+	$regulation = $registry->get( 'gdpr' );
+
+	expect( $regulation )->toBeInstanceOf( PrivacyRegulation::class );
+	expect( $regulation->name() )->toBe( 'GDPR (custom)' );
+	expect( $regulation->getDataRights() )->toContain( 'erasure' );
+} );
+
+it( 'returns every enabled regulation in all()', function (): void {
+	$registry = app( RegulationRegistry::class );
+
+	$all = $registry->all();
+
+	expect( $all )->toHaveKey( 'gdpr' );
+	expect( $all )->toHaveKey( 'ccpa' );
+	expect( $all )->not->toHaveKey( 'lgpd' );
+} );
+
+it( 'identifies the applicable regulation from a request header', function (): void {
+	$registry = app( RegulationRegistry::class );
+
+	$request = Request::create( '/' );
+	$request->headers->set( 'X-Region', 'EU' );
+
+	$regulation = $registry->applicableFor( $request );
+
+	expect( $regulation?->key() )->toBe( 'gdpr' );
+} );
+
+it( 'returns multiple matches when the visitor is subject to several regulations', function (): void {
+	$registry = app( RegulationRegistry::class );
+
+	$request = Request::create( '/' );
+	$request->attributes->set( 'privacy_region', 'EU' );
+
+	$matches = $registry->applicable( $request );
+
+	$keys = array_map( static fn ( PrivacyRegulation $r ): string => $r->key(), $matches );
+
+	expect( $keys )->toContain( 'gdpr' );
+	expect( $keys )->not->toContain( 'ccpa' );
+} );

--- a/tests/Feature/Services/PersonalDataScannerTest.php
+++ b/tests/Feature/Services/PersonalDataScannerTest.php
@@ -123,3 +123,34 @@ it( 'classifies SSN-style columns as sensitive', function (): void {
 
 	expect( $fields['ssn']['sensitivity'] )->toBe( PersonalDataMap::SENSITIVITY_SENSITIVE );
 } );
+
+it( 'does not classify columns that merely contain a pattern as personal data', function (): void {
+	Schema::create( 'scan_false_positives', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'username' )->nullable();
+		$table->string( 'tenant_id' )->nullable();
+		$table->string( 'filename' )->nullable();
+		$table->string( 'microphone_id' )->nullable();
+	} );
+
+	if ( ! class_exists( ScannerFalsePositiveSubject::class ) ) {
+		eval( <<<'PHP'
+			class ScannerFalsePositiveSubject extends \Illuminate\Database\Eloquent\Model
+			{
+				public $timestamps = false;
+				protected $table = 'scan_false_positives';
+				protected $guarded = [];
+			}
+		PHP );
+	}
+
+	$scanner = new PersonalDataScanner();
+	$fields  = $scanner->scanModel( ScannerFalsePositiveSubject::class );
+
+	expect( $fields )->not->toHaveKey( 'username' );
+	expect( $fields )->not->toHaveKey( 'tenant_id' );
+	expect( $fields )->not->toHaveKey( 'filename' );
+	expect( $fields )->not->toHaveKey( 'microphone_id' );
+
+	Schema::dropIfExists( 'scan_false_positives' );
+} );

--- a/tests/Feature/Services/PersonalDataScannerTest.php
+++ b/tests/Feature/Services/PersonalDataScannerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\PersonalDataMap;
+use ArtisanPackUI\Privacy\Services\PersonalDataScanner;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach( function (): void {
+	Schema::create( 'scan_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'email' )->nullable();
+		$table->string( 'first_name' )->nullable();
+		$table->string( 'phone' )->nullable();
+		$table->string( 'random_column' )->nullable();
+	} );
+
+	if ( ! class_exists( ScannerSubject::class ) ) {
+		eval( <<<'PHP'
+			class ScannerSubject extends \Illuminate\Database\Eloquent\Model
+			{
+				public $timestamps = false;
+				protected $table = 'scan_subjects';
+				protected $guarded = [];
+			}
+		PHP );
+	}
+
+	if ( ! class_exists( ScannerSubjectWithTrait::class ) ) {
+		eval( <<<'PHP'
+			class ScannerSubjectWithTrait extends \Illuminate\Database\Eloquent\Model
+			{
+				use \ArtisanPackUI\Privacy\Concerns\HasPersonalData;
+
+				public $timestamps = false;
+				protected $table = 'scan_subjects';
+				protected $guarded = [];
+
+				public function personalDataFields(): array
+				{
+					return [
+						'email' => [
+							'type'              => 'email',
+							'sensitivity'       => 'normal',
+							'deletion_strategy' => 'anonymize',
+						],
+					];
+				}
+			}
+		PHP );
+	}
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'scan_subjects' );
+} );
+
+it( 'detects pattern-matched personal data fields on a plain Eloquent model', function (): void {
+	$scanner = new PersonalDataScanner();
+
+	$fields = $scanner->scanModel( ScannerSubject::class );
+
+	expect( $fields )->toHaveKey( 'email' );
+	expect( $fields['email']['data_type'] )->toBe( 'email' );
+	expect( $fields['email']['auto_discovered'] )->toBeTrue();
+	expect( $fields )->toHaveKey( 'first_name' );
+	expect( $fields['first_name']['data_type'] )->toBe( 'name' );
+	expect( $fields )->toHaveKey( 'phone' );
+	expect( $fields )->not->toHaveKey( 'random_column' );
+} );
+
+it( 'includes trait-declared metadata in the scan result', function (): void {
+	$scanner = new PersonalDataScanner();
+
+	$fields = $scanner->scanModel( ScannerSubjectWithTrait::class );
+
+	expect( $fields['email']['source'] )->toBe( PersonalDataScanner::SOURCE_TRAIT );
+	expect( $fields['email']['auto_discovered'] )->toBeFalse();
+} );
+
+it( 'persists discovered mappings without duplicating rows on re-scan', function (): void {
+	$scanner = new PersonalDataScanner();
+	$fields  = $scanner->scanModel( ScannerSubject::class );
+
+	$scanner->persist( [ ScannerSubject::class => $fields ] );
+	$scanner->persist( [ ScannerSubject::class => $fields ] );
+
+	expect( PersonalDataMap::query()->where( 'model', ScannerSubject::class )->count() )
+		->toBe( count( $fields ) );
+} );
+
+it( 'getFieldMappings returns persisted rows keyed by field', function (): void {
+	$scanner = new PersonalDataScanner();
+
+	$scanner->registerField( ScannerSubject::class, 'email', [
+		'type'              => 'email',
+		'sensitivity'       => 'sensitive',
+		'deletion_strategy' => 'delete',
+	] );
+
+	$map = $scanner->getFieldMappings( ScannerSubject::class );
+
+	expect( $map['email']['sensitivity'] )->toBe( 'sensitive' );
+	expect( $map['email']['deletion_strategy'] )->toBe( 'delete' );
+} );
+
+it( 'respects the excluded models list', function (): void {
+	config()->set( 'artisanpack.privacy.discovery.exclude_models', [ ScannerSubject::class ] );
+
+	$scanner = new PersonalDataScanner();
+
+	expect( $scanner->scanModel( ScannerSubject::class ) )->toBe( [] );
+} );
+
+it( 'classifies SSN-style columns as sensitive', function (): void {
+	Schema::table( 'scan_subjects', function ( Blueprint $table ): void {
+		$table->string( 'ssn' )->nullable();
+	} );
+
+	$scanner = new PersonalDataScanner();
+	$fields  = $scanner->scanModel( ScannerSubject::class );
+
+	expect( $fields['ssn']['sensitivity'] )->toBe( PersonalDataMap::SENSITIVITY_SENSITIVE );
+} );


### PR DESCRIPTION
## Description

Bundles five small, related package issues into a single PR — they all sit at the foundation layer (regulations, personal-data mapping, the user-facing dashboard) and would have churned each other if shipped separately.

**Closes:** #21, #22, #23, #24, #25

## Type of Change

- [x] New feature (adds new functionality)

## Related Issues

- #21 — PrivacyDashboard component (user-facing)
- #22 — HasPersonalData model trait
- #23 — PersonalDataScanner service
- #24 — `privacy:scan` Artisan command
- #25 — BaseRegulation class and regulation system

## Motivation and Context

These five issues form one coherent slice of the v1.0 milestone:
- #25 gives every other piece a structured way to ask "which regulation applies and what does it require?".
- #22 lets the rest of the package treat any Eloquent model uniformly.
- #23 + #24 give DPOs a runnable inventory of where personal data actually lives.
- #21 surfaces all of the above to the end user in a single dashboard.

Shipping them together avoids the awkward intermediate states where, for example, the dashboard exists before the regulation registry it references.

## Changes Made

### #25 — Regulation system
- `Contracts/PrivacyRegulation` interface defining `key`, `name`, `getConsentRequirements`, `getDataRights`, `getRetentionRules`, `getBreachNotificationHours`, `getResponseDays`, `applies`.
- `Regulations/BaseRegulation` abstract class with config-driven defaults and an `applies()` implementation that resolves region from the `privacy_region` request attribute, the `X-Region` header, or the `geolocation.fallback_region` config.
- `Regulations/GenericRegulation` config-only fallback for keys without a dedicated subclass.
- `Regulations/RegulationRegistry` for `register`, `registerClass`, `get`, `all`, `applicable`, `applicableFor` — registered as a singleton; bound as `privacy.regulations`.
- `getApplicableRegulation()` global helper.

### #22 — `HasPersonalData` trait
- Added per-field metadata support (`type`, `sensitivity`, `deletion_strategy`, `retention_period`, `export_format`) on top of the existing plain-list shape.
- New methods: `personalDataFieldNames`, `personalDataFieldMetadata`, `getPersonalData`, `anonymizePersonalData`, `deletePersonalData`.
- New `Traits/HasPersonalData` namespace as an alias for applications following the more generic `App\Traits\…` convention — both register the same canonical trait.

### #23 — `PersonalDataScanner` service
- `scan()`, `scanModel()`, `registerField()`, `getFieldMappings()`, `generateDataInventory()`, `persist()`.
- Discovers models by walking the configured scan paths, parses namespaces from file contents, and inspects via reflection.
- Combines trait-declared metadata with pattern-matched discovery; honours the `discovery.exclude_models` allowlist.
- Promotes SSN-like types to `SENSITIVITY_SENSITIVE` automatically.

### #24 — `privacy:scan` Artisan command
- `--model=` for single-model scans, `--save` for persistence, `--format=table|json|csv` for output.
- Table output highlights sensitive fields and marks drift between this scan and the persisted map (`(new)` / `(changed)`).

### #21 — `PrivacyDashboard` component (Livewire + React + Vue)
- `Livewire\PrivacyDashboard` composes the existing `ConsentPreferences` and `DataRequestForm` components, plus a request history table with export download links.
- Reacts to `privacy:data-request-submitted` and `privacy:consent-updated` events to keep the dashboard in sync.
- React and Vue versions live under `resources/js/{react,vue}/PrivacyDashboard.{tsx,vue}` per the package's pivot to multi-framework support. Both fetch history from the new `GET /api/privacy/data-requests` endpoint.
- Supporting controller method: `DataRequestApiController::index` returns the authenticated subject's history with download URLs scoped to completed export requests, plus the regulation key for badge display.

## How Has This Been Tested?

**Testing Environment:**
- PHP: 8.4 (CI matrix covers 8.2+)
- Project Version: 1.0.0-dev (release/1.0)

**Tests Performed:**
1. `./vendor/bin/pest` — full suite (223 passed, 516 assertions).
2. `./vendor/bin/phpcs` — clean.
3. `./vendor/bin/php-cs-fixer fix --dry-run --diff` — clean.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:** Dashboard sections use `aria-labelledby` with explicit heading IDs; the consent regulation badge announces via `aria-live="polite"`; loading states use `aria-busy`; the history table includes column scopes. Screen-reader-only walkthrough recommended before promoting out of draft.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** New test files —
- `tests/Feature/Regulations/RegulationRegistryTest.php`
- `tests/Feature/Concerns/HasPersonalDataTest.php`
- `tests/Feature/Services/PersonalDataScannerTest.php`
- `tests/Feature/Console/PrivacyScanTest.php`
- `tests/Feature/Livewire/PrivacyDashboardTest.php`
- Appended history-endpoint tests to `tests/Feature/Http/DataRequestApiTest.php`.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Every new class, trait, and method has a PHPDoc block following the package's existing conventions; the regulation contract documents which methods subclasses must override; the dashboard view file is annotated where the section composition is non-obvious.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Privacy Dashboard (Vue/React + Livewire) to manage consent preferences, submit privacy requests, and view request history with export downloads.
  * Introduced a new API endpoint to fetch request history, with a privacy-focused rate limit.
  * Added a `privacy:scan` command to discover personal-data fields across models.
  * Expanded the privacy regulation system with a common regulation interface and a default fallback regulation.
* **Tests**
  * Added/extended feature tests for the dashboard, request history API, regulation registry, and scanning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->