### PR TITLE
feat(privacy): policy management, display, re-consent + view customization (#36-#40)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
+    "league/commonmark": "^2.4",
     "livewire/livewire": "^3.5"
   },
   "require-dev": {

--- a/config/artisanpack/privacy.php
+++ b/config/artisanpack/privacy.php
@@ -356,7 +356,47 @@ return [
 			'show_customize'  => true,
 			'blur_background' => false,
 		],
-		'theme' => 'auto',
+		'policy' => [
+			'custom_css_class'      => env( 'PRIVACY_POLICY_VIEW_CLASS', '' ),
+			'show_version_history'  => true,
+			'show_locale_switcher'  => true,
+		],
+
+		/*
+		| Banner-wide presentation toggles consumed by both the Livewire
+		| views and their React/Vue counterparts so customising one stays
+		| in sync with the other. `use_daisyui` allows applications that
+		| don't ship daisyUI to opt out of the default button classes.
+		*/
+		'animation'       => env( 'PRIVACY_UI_ANIMATION', 'slide-up' ),
+		'z_index'         => (int) env( 'PRIVACY_UI_Z_INDEX', 9999 ),
+		'custom_css_class' => env( 'PRIVACY_UI_CUSTOM_CLASS', '' ),
+		'use_daisyui'     => env( 'PRIVACY_UI_USE_DAISYUI', true ),
+		'theme'           => 'auto',
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Policy Lifecycle
+	|--------------------------------------------------------------------------
+	|
+	| Controls the public-facing policy display and the re-consent workflow.
+	| `reconsent_grace_period_days` allows users to keep using the
+	| application while they review a new policy; `block_on_no_reconsent`
+	| escalates to a hard block once the grace period elapses.
+	|
+	*/
+	'policy' => [
+		'path'                        => env( 'PRIVACY_POLICY_PATH', 'policy' ),
+		'reconsent_path'              => env( 'PRIVACY_RECONSENT_PATH', 'reconsent' ),
+		'reconsent_grace_period_days' => (int) env( 'PRIVACY_RECONSENT_GRACE_DAYS', 30 ),
+		'block_on_no_reconsent'       => (bool) env( 'PRIVACY_RECONSENT_BLOCK', false ),
+		'retention_account_days'      => (int) env( 'PRIVACY_RETENTION_ACCOUNT_DAYS', 90 ),
+		'blocked_response' => [
+			'status'         => 403,
+			'redirect_route' => 'privacy.policy.show',
+			'message'        => 'You must accept the updated privacy policy to continue.',
+		],
 	],
 
 	/*

--- a/database/migrations/2026_06_20_000001_add_policy_version_to_privacy_consents.php
+++ b/database/migrations/2026_06_20_000001_add_policy_version_to_privacy_consents.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::table( 'privacy_consents', function ( Blueprint $table ): void {
+			$table->string( 'policy_version', 64 )->nullable()->after( 'regulation' );
+			$table->index( 'policy_version', 'privacy_consents_policy_version_idx' );
+		} );
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::table( 'privacy_consents', function ( Blueprint $table ): void {
+			$table->dropIndex( 'privacy_consents_policy_version_idx' );
+			$table->dropColumn( 'policy_version' );
+		} );
+	}
+};

--- a/resources/css/privacy.css
+++ b/resources/css/privacy.css
@@ -1,0 +1,102 @@
+/**
+ * ArtisanPack UI · Privacy — default CSS variable map.
+ *
+ * Override any of these variables in your application stylesheet (or in
+ * `:root[data-theme="dark"]` for dark mode) to retheme the cookie banner,
+ * re-consent banner, preferences modal, and policy display page without
+ * publishing the views.
+ *
+ * @since 1.0.0
+ */
+
+:root {
+	/* Layout */
+	--privacy-banner-radius: 0.5rem;
+	--privacy-banner-padding: 1.25rem;
+	--privacy-banner-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+
+	/* Banner — light */
+	--privacy-banner-bg: #ffffff;
+	--privacy-banner-text: #111827;
+	--privacy-banner-border: #e5e7eb;
+
+	/* Banner — accent (CTA) */
+	--privacy-banner-accent: #2563eb;
+	--privacy-banner-accent-text: #ffffff;
+
+	/* Re-consent banner */
+	--privacy-reconsent-bg: #fef3c7;
+	--privacy-reconsent-text: #111827;
+
+	/* Policy page */
+	--privacy-toc-bg: #f8fafc;
+	--privacy-toc-text: #1f2937;
+	--privacy-body-text: #111827;
+	--privacy-link: #1d4ed8;
+}
+
+:root[data-theme="dark"],
+@media (prefers-color-scheme: dark) {
+	:root:not([data-theme="light"]) {
+		--privacy-banner-bg: #1f2937;
+		--privacy-banner-text: #f9fafb;
+		--privacy-banner-border: #374151;
+		--privacy-reconsent-bg: #422006;
+		--privacy-reconsent-text: #f9fafb;
+		--privacy-toc-bg: #1f2937;
+		--privacy-toc-text: #f9fafb;
+		--privacy-body-text: #f3f4f6;
+		--privacy-link: #93c5fd;
+	}
+}
+
+/* Component scaffolding — only used when `ui.use_daisyui` is set to false. */
+.privacy-cookie-banner__inner,
+.privacy-reconsent-banner__inner {
+	background: var(--privacy-banner-bg);
+	color: var(--privacy-banner-text);
+	border-radius: var(--privacy-banner-radius);
+	box-shadow: var(--privacy-banner-shadow);
+	padding: var(--privacy-banner-padding);
+}
+
+.privacy-cookie-banner__btn,
+.privacy-reconsent-banner__btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0.5rem 1rem;
+	border-radius: calc(var(--privacy-banner-radius) / 2);
+	border: 1px solid var(--privacy-banner-border);
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	font-weight: 500;
+}
+
+.privacy-cookie-banner__btn:hover,
+.privacy-reconsent-banner__btn:hover {
+	border-color: var(--privacy-banner-accent);
+	color: var(--privacy-banner-accent);
+}
+
+.privacy-cookie-banner__btn.btn-primary,
+.privacy-reconsent-banner__btn.btn-primary {
+	background: var(--privacy-banner-accent);
+	border-color: var(--privacy-banner-accent);
+	color: var(--privacy-banner-accent-text);
+}
+
+.privacy-cookie-banner__category {
+	border: 1px solid var(--privacy-banner-border);
+	border-radius: calc(var(--privacy-banner-radius) / 2);
+}
+
+.privacy-cookie-banner__badge {
+	display: inline-block;
+	padding: 0.125rem 0.5rem;
+	border-radius: 9999px;
+	background: var(--privacy-banner-border);
+	font-size: 0.75rem;
+	font-weight: 500;
+}

--- a/resources/js/react/PolicyReconsentBanner.tsx
+++ b/resources/js/react/PolicyReconsentBanner.tsx
@@ -1,0 +1,148 @@
+/**
+ * PolicyReconsentBanner — React companion to the Livewire re-consent banner.
+ *
+ * Polls the package's consent endpoint to discover whether the current
+ * active policy requires re-consent (carried via the `_policy_version`
+ * metadata on the consent state). Renders nothing until a stale policy
+ * version is detected, then exposes Accept / Review / Dismiss actions.
+ *
+ * @since 1.0.0
+ */
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { getPrivacyClient, type PrivacyClientOptions } from '../privacy';
+
+export interface PolicyReconsentPayload {
+	version: string;
+	regulation?: string | null;
+	url?: string;
+}
+
+export interface PolicyReconsentBannerProps extends PrivacyClientOptions {
+	policy: PolicyReconsentPayload | null;
+	className?: string;
+	buttonClassName?: string;
+	header?: ReactNode;
+	description?: ReactNode;
+	footer?: ReactNode;
+	labels?: {
+		title?: string;
+		description?: string;
+		review?: string;
+		accept?: string;
+		dismiss?: string;
+	};
+	policyUrl?: string;
+	reconsentUrl?: string;
+	onAccept?: ( version: string ) => void;
+	onDismiss?: () => void;
+}
+
+export function PolicyReconsentBanner( props: PolicyReconsentBannerProps ): JSX.Element | null {
+	const {
+		policy,
+		className,
+		buttonClassName,
+		header,
+		description,
+		footer,
+		labels,
+		policyUrl = '/privacy/policy',
+		reconsentUrl = '/privacy/reconsent',
+		onAccept,
+		onDismiss,
+		...clientOptions
+	} = props;
+
+	const client = useMemo( () => getPrivacyClient( clientOptions ), [ clientOptions ] );
+	const [ dismissed, setDismissed ] = useState( false );
+	const [ saving, setSaving ] = useState( false );
+
+	useEffect( () => {
+		setDismissed( false );
+	}, [ policy?.version ] );
+
+	if ( null === policy || dismissed ) {
+		return null;
+	}
+
+	const resolvedLabels = {
+		title: labels?.title ?? 'Our privacy policy has been updated',
+		description: labels?.description ?? 'Please review the updated policy and confirm that you accept the new terms.',
+		review: labels?.review ?? 'Review policy',
+		accept: labels?.accept ?? 'Accept updated policy',
+		dismiss: labels?.dismiss ?? 'Remind me later',
+	};
+
+	const handleAccept = async (): Promise<void> => {
+		setSaving( true );
+		try {
+			const csrf =
+				typeof document !== 'undefined'
+					? document.querySelector<HTMLMetaElement>( 'meta[name="csrf-token"]' )?.content
+					: undefined;
+			await fetch( reconsentUrl, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+					...( csrf ? { 'X-CSRF-TOKEN': csrf } : {} ),
+				},
+				credentials: 'same-origin',
+				body: JSON.stringify( {
+					version: policy.version,
+					regulation: policy.regulation ?? null,
+				} ),
+			} );
+			setDismissed( true );
+			onAccept?.( policy.version );
+			void client.load();
+		} finally {
+			setSaving( false );
+		}
+	};
+
+	const handleDismiss = (): void => {
+		setDismissed( true );
+		onDismiss?.();
+	};
+
+	const buttonClass = buttonClassName ?? 'privacy-reconsent-banner__btn';
+
+	return (
+		<div
+			role="alertdialog"
+			aria-modal="false"
+			aria-labelledby="privacy-reconsent-title"
+			className={ className ?? 'privacy-reconsent-banner' }
+			data-privacy-reconsent
+			data-policy-version={ policy.version }
+		>
+			<div className="privacy-reconsent-banner__inner">
+				{ header }
+				<h2 id="privacy-reconsent-title">{ resolvedLabels.title }</h2>
+				{ description ?? <p>{ resolvedLabels.description }</p> }
+				<p className="privacy-reconsent-banner__version">
+					Version: <strong>{ policy.version }</strong>
+				</p>
+				<div className="privacy-reconsent-banner__actions">
+					<a
+						className={ buttonClass }
+						href={ policy.url ?? policyUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ resolvedLabels.review }
+					</a>
+					<button type="button" className={ buttonClass } disabled={ saving } onClick={ handleDismiss }>
+						{ resolvedLabels.dismiss }
+					</button>
+					<button type="button" className={ `${ buttonClass } btn-primary` } disabled={ saving } onClick={ () => void handleAccept() }>
+						{ resolvedLabels.accept }
+					</button>
+				</div>
+				{ footer }
+			</div>
+		</div>
+	);
+}

--- a/resources/js/react/index.ts
+++ b/resources/js/react/index.ts
@@ -18,6 +18,11 @@ export type {
 	PrivacyDashboardRequest,
 	PrivacyDashboardHistoryPayload,
 } from './PrivacyDashboard';
+export { PolicyReconsentBanner } from './PolicyReconsentBanner';
+export type {
+	PolicyReconsentBannerProps,
+	PolicyReconsentPayload,
+} from './PolicyReconsentBanner';
 export { useConsent } from './useConsent';
 export type { UseConsentOptions, UseConsentResult } from './useConsent';
 export {

--- a/resources/js/vue/PolicyReconsentBanner.vue
+++ b/resources/js/vue/PolicyReconsentBanner.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+/**
+ * PolicyReconsentBanner — Vue companion to the Livewire re-consent banner.
+ *
+ * Render in the application's main layout and feed it the active policy
+ * payload (from a shared store, an Inertia prop, or a Livewire bridge).
+ * The component renders nothing when `policy` is null.
+ *
+ * @since 1.0.0
+ */
+
+import { computed, ref, watch } from 'vue';
+import { getPrivacyClient, type PrivacyClientOptions } from '../privacy';
+
+export interface PolicyReconsentPayload {
+	version: string;
+	regulation?: string | null;
+	url?: string;
+}
+
+interface PolicyReconsentBannerProps extends PrivacyClientOptions {
+	policy: PolicyReconsentPayload | null;
+	className?: string;
+	buttonClassName?: string;
+	titleLabel?: string;
+	descriptionLabel?: string;
+	reviewLabel?: string;
+	acceptLabel?: string;
+	dismissLabel?: string;
+	policyUrl?: string;
+	reconsentUrl?: string;
+}
+
+const props = withDefaults( defineProps<PolicyReconsentBannerProps>(), {
+	className: 'privacy-reconsent-banner',
+	buttonClassName: 'privacy-reconsent-banner__btn',
+	titleLabel: 'Our privacy policy has been updated',
+	descriptionLabel: 'Please review the updated policy and confirm that you accept the new terms.',
+	reviewLabel: 'Review policy',
+	acceptLabel: 'Accept updated policy',
+	dismissLabel: 'Remind me later',
+	policyUrl: '/privacy/policy',
+	reconsentUrl: '/privacy/reconsent',
+} );
+
+const emit = defineEmits<{
+	( e: 'accept', version: string ): void;
+	( e: 'dismiss' ): void;
+}>();
+
+const dismissed = ref( false );
+const saving = ref( false );
+
+watch(
+	() => props.policy?.version,
+	() => {
+		dismissed.value = false;
+	},
+);
+
+const visible = computed( () => null !== props.policy && ! dismissed.value );
+
+async function accept(): Promise<void> {
+	if ( null === props.policy ) {
+		return;
+	}
+	saving.value = true;
+	try {
+		const csrf =
+			typeof document !== 'undefined'
+				? document.querySelector<HTMLMetaElement>( 'meta[name="csrf-token"]' )?.content
+				: undefined;
+		await fetch( props.reconsentUrl, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				...( csrf ? { 'X-CSRF-TOKEN': csrf } : {} ),
+			},
+			credentials: 'same-origin',
+			body: JSON.stringify( {
+				version: props.policy.version,
+				regulation: props.policy.regulation ?? null,
+			} ),
+		} );
+		dismissed.value = true;
+		emit( 'accept', props.policy.version );
+		const client = getPrivacyClient();
+		void client.load();
+	} finally {
+		saving.value = false;
+	}
+}
+
+function dismiss(): void {
+	dismissed.value = true;
+	emit( 'dismiss' );
+}
+</script>
+
+<template>
+	<div
+		v-if="visible && policy"
+		role="alertdialog"
+		aria-modal="false"
+		aria-labelledby="privacy-reconsent-title"
+		:class="className"
+		data-privacy-reconsent
+		:data-policy-version="policy.version"
+	>
+		<div class="privacy-reconsent-banner__inner">
+			<slot name="header" />
+			<h2 id="privacy-reconsent-title">{{ titleLabel }}</h2>
+			<slot name="description">
+				<p>{{ descriptionLabel }}</p>
+			</slot>
+			<p class="privacy-reconsent-banner__version">
+				Version: <strong>{{ policy.version }}</strong>
+			</p>
+			<div class="privacy-reconsent-banner__actions">
+				<a
+					:class="buttonClassName"
+					:href="policy.url ?? policyUrl"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{{ reviewLabel }}
+				</a>
+				<button type="button" :class="buttonClassName" :disabled="saving" @click="dismiss">
+					{{ dismissLabel }}
+				</button>
+				<button
+					type="button"
+					:class="`${ buttonClassName } btn-primary`"
+					:disabled="saving"
+					@click="accept"
+				>
+					{{ acceptLabel }}
+				</button>
+			</div>
+			<slot name="footer" />
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -13,6 +13,8 @@ export type {
 	PrivacyDashboardRequest,
 	PrivacyDashboardHistoryPayload,
 } from './PrivacyDashboard.vue';
+export { default as PolicyReconsentBanner } from './PolicyReconsentBanner.vue';
+export type { PolicyReconsentPayload } from './PolicyReconsentBanner.vue';
 export { useConsent } from './useConsent';
 export type { UseConsentOptions, UseConsentResult } from './useConsent';
 export {

--- a/resources/templates/policies/ccpa.md
+++ b/resources/templates/policies/ccpa.md
@@ -1,0 +1,73 @@
+# {{company_name}} Privacy Notice for California Residents
+
+_Last updated: {{effective_date}}_
+
+This notice supplements our general privacy policy and applies to California residents under the California Consumer Privacy Act ("CCPA") as amended by the California Privacy Rights Act ("CPRA").
+
+## 1. Categories of personal information we collect
+
+In the last twelve (12) months, **{{company_name}}** has collected the following categories of personal information about California residents:
+
+- **Identifiers** — name, email address, IP address, account identifiers.
+- **Customer records** — billing address, phone number, payment information.
+- **Commercial information** — products or services purchased, transaction history.
+- **Internet or other network activity** — browsing history on our site, interaction with our content.
+- **Geolocation data** — approximate location derived from your IP address.
+- **Inferences** — preferences and characteristics derived from the categories above.
+
+## 2. Sources of personal information
+
+We collect personal information from:
+
+- You, directly, when you create an account or submit a form.
+- Your devices, when you interact with our website (cookies, log files).
+- Third-party service providers (e.g. payment processors, analytics providers).
+- Public sources, where permitted by law.
+
+## 3. Purposes of collection
+
+We use personal information for the business purposes described in our general privacy policy, including service delivery, account management, fraud prevention, analytics, and legal compliance.
+
+## 4. Categories of third parties with whom we share personal information
+
+We may disclose personal information to:
+
+- **Service providers** that process data on our behalf (hosting, payment, email, analytics).
+- **Professional advisors** (lawyers, accountants, auditors).
+- **Government authorities** when required by law.
+- **Successors** in the event of a merger, acquisition, or sale of assets.
+
+We do **not** sell personal information for monetary consideration. We may "share" personal information for cross-context behavioral advertising only with your opt-in; you can opt out at any time through the link below.
+
+## 5. Your rights as a California resident
+
+You have the right to:
+
+- **Know** what personal information we have collected about you, the sources, purposes, and recipients.
+- **Delete** personal information we have collected, subject to certain exceptions.
+- **Correct** inaccurate personal information.
+- **Opt out** of the sale or sharing of your personal information.
+- **Limit** the use of sensitive personal information.
+- **Non-discrimination** for exercising your rights.
+
+## 6. How to exercise your rights
+
+To exercise any of the rights described above, you can:
+
+- Email us at **{{company_email}}**.
+- Use the "Do Not Sell or Share My Personal Information" link on our website.
+- Submit a request through your account's privacy dashboard.
+
+We will verify your identity before responding to your request. Authorized agents may submit requests on your behalf with written authorization.
+
+## 7. Non-discrimination
+
+We will not discriminate against you for exercising any of your CCPA rights. We will not deny you goods or services, charge different prices, or provide a different level or quality of goods or services solely because you exercised your rights.
+
+## 8. Financial incentives
+
+We do not currently offer any financial incentive programs that are conditioned on the collection, retention, sale, or sharing of personal information. If we introduce such a program, we will update this notice and obtain your opt-in consent before enrolling you.
+
+## Contact
+
+For questions or concerns about this notice, contact **{{company_name}}** at **{{company_email}}** or {{company_address}}.

--- a/resources/templates/policies/gdpr.md
+++ b/resources/templates/policies/gdpr.md
@@ -1,0 +1,79 @@
+# {{company_name}} Privacy Policy
+
+_Last updated: {{effective_date}}_
+
+This privacy policy explains how **{{company_name}}** ("we", "us", or "our") collects, uses, discloses, and safeguards your personal data when you visit {{company_website}} or otherwise interact with our services. We process personal data in accordance with the General Data Protection Regulation (GDPR) and, where applicable, the United Kingdom GDPR.
+
+## 1. Identity and contact details
+
+The data controller responsible for your personal data is:
+
+- **{{company_name}}**
+- {{company_address}}
+- Email: {{company_email}}
+- Website: {{company_website}}
+
+Our Data Protection Officer can be reached at **{{dpo_email}}**{{#dpo_phone}} or by phone at **{{dpo_phone}}**{{/dpo_phone}}.
+
+## 2. Types of personal data we collect
+
+We may collect and process the following categories of personal data:
+
+- **Identity data**: name, username, date of birth.
+- **Contact data**: email address, postal address, telephone number.
+- **Technical data**: IP address, browser type, device identifiers, log data.
+- **Usage data**: information about how you use our website and services.
+- **Marketing and communications data**: your preferences in receiving marketing from us.
+
+## 3. Purposes of processing
+
+We process your personal data for the following purposes:
+
+- To provide and maintain our services.
+- To manage your account and relationship with us.
+- To improve our website, products, and services.
+- To send service announcements and, with your consent, marketing communications.
+- To comply with legal and regulatory obligations.
+
+## 4. Legal basis for processing
+
+We rely on one or more of the following legal bases under Article 6(1) of the GDPR:
+
+- **Consent** for marketing communications and optional cookies.
+- **Performance of a contract** when you sign up for our services.
+- **Legal obligation** for tax, accounting, and regulatory record-keeping.
+- **Legitimate interests** for analytics that improve our services, provided your rights do not override these interests.
+
+## 5. Data retention periods
+
+We retain personal data only for as long as is necessary for the purposes set out above, including any period required to satisfy legal, accounting, or reporting requirements. Account data is retained for the duration of your account and **{{retention_account_days}} days** thereafter. Marketing preferences are retained until you withdraw your consent.
+
+## 6. Your rights as a data subject
+
+Subject to the conditions set out in the GDPR, you have the right to:
+
+- Request **access** to your personal data.
+- Request **rectification** of inaccurate or incomplete data.
+- Request **erasure** ("right to be forgotten") of your data.
+- Request **restriction** of processing in certain circumstances.
+- Request **data portability** of data you have provided to us.
+- **Object** to processing carried out on the basis of legitimate interests or for direct marketing.
+- Not be subject to a decision based solely on **automated decision-making**, including profiling, that produces legal effects concerning you.
+
+To exercise any of these rights, contact us at **{{company_email}}** or through your account's privacy dashboard.
+
+## 7. Right to withdraw consent
+
+Where we process your personal data on the basis of your consent, you have the right to withdraw that consent at any time. Withdrawal does not affect the lawfulness of processing based on consent before its withdrawal.
+
+## 8. Right to lodge a complaint
+
+You have the right to lodge a complaint with your local supervisory authority if you believe that our processing of your personal data infringes the GDPR. A list of supervisory authorities is available at <https://edpb.europa.eu/about-edpb/about-edpb/members_en>.
+
+## 9. International data transfers
+
+We may transfer your personal data outside of the European Economic Area only when an appropriate safeguard is in place — typically the European Commission's Standard Contractual Clauses or an adequacy decision. If you would like a copy of the safeguards we rely on, contact **{{dpo_email}}**.
+
+## 10. Automated decision-making
+
+We do not make decisions about you based solely on automated processing that produce legal or similarly significant effects, except where strictly necessary for entering into or performing a contract with you, or where you have given your explicit consent. Where automated decision-making is used, you have the right to obtain human intervention, to express your point of view, and to contest the decision.

--- a/resources/templates/policies/general.md
+++ b/resources/templates/policies/general.md
@@ -1,0 +1,45 @@
+# {{company_name}} Privacy Policy
+
+_Last updated: {{effective_date}}_
+
+This privacy policy describes how **{{company_name}}** ("we", "us", or "our") collects, uses, and protects your personal information when you visit {{company_website}} or otherwise interact with our services.
+
+## 1. Who we are
+
+**{{company_name}}** — {{company_address}}. You can contact us at **{{company_email}}**{{#dpo_email}}; our Data Protection Officer can be reached at **{{dpo_email}}**{{/dpo_email}}.
+
+## 2. What we collect
+
+We may collect:
+
+- Account and contact information you provide.
+- Usage information about how you interact with our services.
+- Device and technical information such as IP address and browser type.
+
+## 3. How we use your information
+
+We use personal information to:
+
+- Provide and improve our services.
+- Communicate with you about your account or our services.
+- Comply with legal obligations and protect against fraud.
+
+## 4. Sharing
+
+We share personal information only with service providers that help us operate our services, when required by law, or with your consent.
+
+## 5. Your choices
+
+You may access, correct, or delete your account information at any time by contacting **{{company_email}}**. You may also opt out of marketing communications at any time.
+
+## 6. Security
+
+We use reasonable technical and organisational measures to protect personal information from unauthorised access, alteration, disclosure, or destruction.
+
+## 7. Changes to this policy
+
+We may update this policy from time to time. We will notify you of material changes by posting a notice on our website or by other reasonable means.
+
+## 8. Contact
+
+For questions about this policy, contact **{{company_name}}** at **{{company_email}}**.

--- a/resources/templates/policies/lgpd.md
+++ b/resources/templates/policies/lgpd.md
@@ -1,0 +1,43 @@
+# Política de Privacidade {{company_name}}
+
+_Última atualização: {{effective_date}}_
+
+Esta política descreve como **{{company_name}}** ("nós") trata os dados pessoais em conformidade com a Lei Geral de Proteção de Dados (Lei nº 13.709/2018 — LGPD).
+
+## 1. Controlador
+
+**{{company_name}}** — {{company_address}} — {{company_email}} é o controlador dos dados pessoais coletados por meio de {{company_website}}.
+
+## 2. Encarregado (DPO)
+
+O encarregado de proteção de dados pode ser contatado em **{{dpo_email}}**.
+
+## 3. Categorias de dados pessoais coletados
+
+- Dados de identificação: nome, e-mail, CPF (quando aplicável).
+- Dados de contato: telefone, endereço.
+- Dados de uso: registros de acesso, IP, dispositivo.
+
+## 4. Finalidades do tratamento
+
+Tratamos dados pessoais para: prestar nossos serviços, gerenciar a sua conta, cumprir obrigações legais e regulatórias e melhorar nossos produtos.
+
+## 5. Bases legais
+
+Utilizamos as bases legais previstas no artigo 7º da LGPD: consentimento, cumprimento de obrigação legal, execução de contrato, exercício regular de direitos, proteção da vida e legítimo interesse, conforme aplicável.
+
+## 6. Direitos do titular
+
+Você tem o direito de: confirmação e acesso, correção, anonimização, portabilidade, eliminação, informação sobre compartilhamento, revogação do consentimento e oposição ao tratamento. Para exercer, envie um pedido para **{{company_email}}**.
+
+## 7. Compartilhamento
+
+Compartilhamos dados apenas com operadores que prestam serviços a {{company_name}} ou quando exigido por lei. Transferências internacionais ocorrem somente para países que ofereçam grau de proteção adequado ou mediante garantias contratuais específicas.
+
+## 8. Retenção e segurança
+
+Mantemos dados pessoais somente pelo tempo necessário para cumprir as finalidades informadas ou para atender a exigências legais. Adotamos medidas técnicas e administrativas para proteger seus dados.
+
+## 9. Autoridade Nacional de Proteção de Dados
+
+Você pode apresentar reclamação à ANPD em <https://www.gov.br/anpd>.

--- a/resources/templates/policies/pipeda.md
+++ b/resources/templates/policies/pipeda.md
@@ -1,0 +1,45 @@
+# {{company_name}} Privacy Policy (PIPEDA)
+
+_Last updated: {{effective_date}}_
+
+This policy describes how **{{company_name}}** handles personal information in accordance with Canada's Personal Information Protection and Electronic Documents Act ("PIPEDA").
+
+## 1. Accountability
+
+**{{company_name}}** is responsible for personal information under our control. Our Privacy Officer can be reached at **{{dpo_email}}** or {{company_address}}.
+
+## 2. Identifying purposes
+
+We collect personal information to provide our services, manage your account, communicate with you, comply with legal obligations, and improve our products. We identify these purposes at or before the time of collection.
+
+## 3. Consent
+
+Your knowledge and consent are required for the collection, use, or disclosure of personal information, except where inappropriate (e.g., legal investigations). You may withdraw consent at any time, subject to legal or contractual restrictions, by contacting **{{company_email}}**.
+
+## 4. Limiting collection
+
+We collect only the personal information necessary for the purposes identified. We use fair and lawful means of collection.
+
+## 5. Limiting use, disclosure, and retention
+
+We use or disclose personal information only for the purposes for which it was collected, except with your consent or as required by law. We retain personal information only as long as necessary to fulfil those purposes.
+
+## 6. Accuracy
+
+We keep personal information as accurate, complete, and up-to-date as is necessary for the purposes for which it is used.
+
+## 7. Safeguards
+
+We protect personal information with security safeguards appropriate to its sensitivity, including physical, organisational, and technological measures.
+
+## 8. Openness
+
+This policy and additional information about our privacy practices are available at {{company_website}}.
+
+## 9. Individual access
+
+You may request access to your personal information held by us, request correction of inaccuracies, and obtain an account of its use and disclosure by contacting **{{company_email}}**.
+
+## 10. Challenging compliance
+
+You may challenge our compliance with PIPEDA by contacting our Privacy Officer at **{{dpo_email}}**. If you are not satisfied with our response, you may file a complaint with the Office of the Privacy Commissioner of Canada at <https://www.priv.gc.ca>.

--- a/resources/views/livewire/cookie-banner.blade.php
+++ b/resources/views/livewire/cookie-banner.blade.php
@@ -45,6 +45,8 @@
 	x-transition:enter-start="{{ $enterStart }}"
 	x-transition:enter-end="{{ $enterEnd }}"
 	x-transition:leave="transition ease-in duration-200"
+	x-transition:leave-start="{{ $enterEnd }}"
+	x-transition:leave-end="{{ $enterStart }}"
 	x-trap.noscroll.inert="visible && '{{ $this->style }}' === 'modal'"
 	role="dialog"
 	aria-modal="{{ $this->style === 'modal' ? 'true' : 'false' }}"

--- a/resources/views/livewire/cookie-banner.blade.php
+++ b/resources/views/livewire/cookie-banner.blade.php
@@ -5,8 +5,35 @@
 		'bottom-left'  => 'bottom-4 left-4 max-w-md',
 		'bottom-right' => 'bottom-4 right-4 max-w-md',
 	];
-	$position = $positionClasses[$this->position] ?? $positionClasses['bottom'];
+	$position  = $positionClasses[$this->position] ?? $positionClasses['bottom'];
 	$ariaLabel = __( 'Cookie consent' );
+
+	$labels = array_merge( [
+		'title'          => __( 'We value your privacy' ),
+		'description'    => __( 'We use cookies to make our website work and to understand how it is used. You can choose which categories you allow.' ),
+		'accept_all'     => __( 'Accept all' ),
+		'reject_all'     => __( 'Reject all' ),
+		'customise'      => __( 'Customise' ),
+		'save'           => __( 'Save selection' ),
+		'required_badge' => __( 'Required' ),
+	], $labels );
+
+	$animation = (string) config( 'artisanpack.privacy.ui.animation', 'slide-up' );
+	$zIndex    = (int) config( 'artisanpack.privacy.ui.z_index', 9999 );
+	$useDaisy  = true === config( 'artisanpack.privacy.ui.use_daisyui', true );
+	$baseBtn   = '' !== $buttonClasses
+		? $buttonClasses
+		: ( $useDaisy ? 'btn' : 'privacy-cookie-banner__btn' );
+
+	$enterStart = match ( $animation ) {
+		'fade'  => 'opacity-0',
+		'none'  => '',
+		default => 'opacity-0 translate-y-4',
+	};
+	$enterEnd = match ( $animation ) {
+		'none'  => '',
+		default => 'opacity-100 translate-y-0',
+	};
 @endphp
 
 <div
@@ -14,29 +41,40 @@
 	x-cloak
 	x-show="visible"
 	x-on:privacy:open-preferences.window="$wire.openFromGlobal()"
+	x-transition:enter="transition ease-out duration-300"
+	x-transition:enter-start="{{ $enterStart }}"
+	x-transition:enter-end="{{ $enterEnd }}"
+	x-transition:leave="transition ease-in duration-200"
 	x-trap.noscroll.inert="visible && '{{ $this->style }}' === 'modal'"
 	role="dialog"
 	aria-modal="{{ $this->style === 'modal' ? 'true' : 'false' }}"
 	aria-label="{{ $ariaLabel }}"
+	style="
+		z-index: {{ $zIndex }};
+		--privacy-banner-bg: var(--privacy-banner-bg, currentColor);
+		--privacy-banner-radius: var(--privacy-banner-radius, 0.5rem);
+		--privacy-banner-shadow: var(--privacy-banner-shadow, 0 25px 50px -12px rgb(0 0 0 / 0.25));
+	"
 	@if($style === 'modal')
-		class="fixed inset-0 z-[9999] flex items-end sm:items-center justify-center bg-black/40 p-4"
+		class="fixed inset-0 flex items-end sm:items-center justify-center bg-black/40 p-4 privacy-cookie-banner {{ $class }}"
 	@else
-		class="fixed {{ $position }} z-[9999] m-2 sm:m-4"
+		class="fixed {{ $position }} m-2 sm:m-4 privacy-cookie-banner {{ $class }}"
 	@endif
+	data-privacy-cookie-banner
 >
 	<div
-		class="bg-base-100 text-base-content dark:bg-neutral dark:text-neutral-content shadow-2xl rounded-lg p-5 sm:p-6 w-full"
-		style="--privacy-banner-bg: var(--privacy-banner-bg, currentColor);"
+		class="{{ $useDaisy ? 'bg-base-100 text-base-content dark:bg-neutral dark:text-neutral-content' : 'privacy-cookie-banner__inner' }} w-full p-5 sm:p-6"
+		style="border-radius: var(--privacy-banner-radius); box-shadow: var(--privacy-banner-shadow);"
 	>
 		<div class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				{{ $header ?? '' }}
 				<h2 class="text-lg font-semibold">
-					{{ __( 'We value your privacy' ) }}
+					{{ $labels['title'] }}
 				</h2>
 				{{ $description ?? '' }}
 				<p class="text-sm opacity-80">
-					{{ __( 'We use cookies to make our website work and to understand how it is used. You can choose which categories you allow.' ) }}
+					{{ $labels['description'] }}
 				</p>
 			</div>
 
@@ -52,14 +90,14 @@
 						@endphp
 						<label
 							for="privacy-banner-toggle-{{ $key }}"
-							class="flex items-start justify-between gap-3 cursor-pointer p-3 rounded border border-base-300"
+							class="flex items-start justify-between gap-3 cursor-pointer p-3 rounded {{ $useDaisy ? 'border border-base-300' : 'privacy-cookie-banner__category' }}"
 						>
 							<span class="flex flex-col">
 								<span class="font-medium">
 									{{ $category['name'] ?? $key }}
 									@if($required)
-										<span class="badge badge-ghost badge-sm ml-1">
-											{{ __( 'Required' ) }}
+										<span class="{{ $useDaisy ? 'badge badge-ghost badge-sm' : 'privacy-cookie-banner__badge' }} ml-1">
+											{{ $labels['required_badge'] }}
 										</span>
 									@endif
 								</span>
@@ -70,7 +108,7 @@
 							<input
 								id="privacy-banner-toggle-{{ $key }}"
 								type="checkbox"
-								class="toggle toggle-primary"
+								class="{{ $useDaisy ? 'toggle toggle-primary' : 'privacy-cookie-banner__toggle' }}"
 								wire:model.live="selected.{{ $key }}"
 								@disabled($required)
 								aria-label="{{ $category['name'] ?? $key }}"
@@ -84,32 +122,32 @@
 				@if($showPreferences)
 					<button
 						type="button"
-						class="btn btn-primary"
+						class="{{ $baseBtn }} {{ $useDaisy ? 'btn-primary' : '' }}"
 						wire:click="saveSelected"
 					>
-						{{ __( 'Save selection' ) }}
+						{{ $labels['save'] }}
 					</button>
 				@else
 					<button
 						type="button"
-						class="btn btn-ghost"
+						class="{{ $baseBtn }} {{ $useDaisy ? 'btn-ghost' : '' }}"
 						wire:click="openPreferences"
 					>
-						{{ __( 'Customise' ) }}
+						{{ $labels['customise'] }}
 					</button>
 					<button
 						type="button"
-						class="btn btn-outline"
+						class="{{ $baseBtn }} {{ $useDaisy ? 'btn-outline' : '' }}"
 						wire:click="rejectAll"
 					>
-						{{ __( 'Reject all' ) }}
+						{{ $labels['reject_all'] }}
 					</button>
 					<button
 						type="button"
-						class="btn btn-primary"
+						class="{{ $baseBtn }} {{ $useDaisy ? 'btn-primary' : '' }}"
 						wire:click="acceptAll"
 					>
-						{{ __( 'Accept all' ) }}
+						{{ $labels['accept_all'] }}
 					</button>
 				@endif
 			</div>

--- a/resources/views/livewire/policy-reconsent-banner.blade.php
+++ b/resources/views/livewire/policy-reconsent-banner.blade.php
@@ -1,0 +1,91 @@
+@php
+	$policy = $this->policy;
+	$labels = array_merge( [
+		'title'       => __( 'Our privacy policy has been updated' ),
+		'description' => __( 'Please review the updated policy and confirm that you accept the new terms to continue using the service.' ),
+		'review'      => __( 'Review policy' ),
+		'accept'      => __( 'Accept updated policy' ),
+		'dismiss'     => __( 'Remind me later' ),
+	], $labels );
+
+	$animation       = (string) config( 'artisanpack.privacy.ui.animation', 'slide-up' );
+	$zIndex          = (int) config( 'artisanpack.privacy.ui.z_index', 9999 );
+	$useDaisy        = true === config( 'artisanpack.privacy.ui.use_daisyui', true );
+	$baseButtonClass = '' !== $buttonClasses
+		? $buttonClasses
+		: ( $useDaisy ? 'btn' : 'privacy-reconsent-banner__btn' );
+@endphp
+
+<div
+	x-data="{ visible: @entangle('visible').live }"
+	x-cloak
+	@if($policy)
+		x-show="visible"
+		x-transition:enter="transition ease-out duration-300"
+		x-transition:enter-start="opacity-0 {{ 'slide-up' === $animation ? 'translate-y-2' : '' }}"
+		x-transition:enter-end="opacity-100 translate-y-0"
+		x-transition:leave="transition ease-in duration-200"
+		x-transition:leave-start="opacity-100 translate-y-0"
+		x-transition:leave-end="opacity-0 {{ 'slide-up' === $animation ? 'translate-y-2' : '' }}"
+		role="alertdialog"
+		aria-modal="false"
+		aria-labelledby="privacy-reconsent-title"
+		class="fixed bottom-0 left-0 right-0 m-4 privacy-reconsent-banner {{ $class }}"
+		style="z-index: {{ $zIndex }};"
+		data-privacy-reconsent
+		data-policy-version="{{ $policy->version }}"
+	@else
+		hidden
+		data-privacy-reconsent="empty"
+	@endif
+>
+	@if($policy)
+		<div
+			class="{{ $useDaisy ? 'bg-base-100 text-base-content dark:bg-neutral dark:text-neutral-content' : 'privacy-reconsent-banner__inner' }} shadow-2xl rounded-lg p-5 sm:p-6 max-w-3xl mx-auto"
+			style="--privacy-banner-bg: var(--privacy-banner-bg, currentColor);"
+		>
+			<div class="flex flex-col gap-3">
+				<div class="flex flex-col gap-1">
+					{{ $header ?? '' }}
+					<h2 id="privacy-reconsent-title" class="text-lg font-semibold">
+						{{ $labels['title'] }}
+					</h2>
+					{{ $description ?? '' }}
+					<p class="text-sm opacity-80">
+						{{ $labels['description'] }}
+					</p>
+					<p class="text-xs opacity-60">
+						{{ __( 'Version' ) }}: <strong>{{ $policy->version }}</strong>
+					</p>
+				</div>
+
+				<div class="flex flex-col sm:flex-row gap-2 sm:justify-end">
+					<a
+						href="{{ route( 'privacy.policy.show' ) }}"
+						target="_blank"
+						rel="noopener"
+						class="{{ $baseButtonClass }} {{ $useDaisy ? 'btn-ghost' : '' }}"
+					>
+						{{ $labels['review'] }}
+					</a>
+					<button
+						type="button"
+						class="{{ $baseButtonClass }} {{ $useDaisy ? 'btn-outline' : '' }}"
+						wire:click="dismiss"
+					>
+						{{ $labels['dismiss'] }}
+					</button>
+					<button
+						type="button"
+						class="{{ $baseButtonClass }} {{ $useDaisy ? 'btn-primary' : '' }}"
+						wire:click="accept"
+					>
+						{{ $labels['accept'] }}
+					</button>
+				</div>
+
+				{{ $footer ?? '' }}
+			</div>
+		</div>
+	@endif
+</div>

--- a/resources/views/policy/show.blade.php
+++ b/resources/views/policy/show.blade.php
@@ -1,0 +1,152 @@
+@php
+	$uiConfig          = (array) config( 'artisanpack.privacy.ui', [] );
+	$policyConfig      = (array) ( $uiConfig['policy'] ?? [] );
+	$customClass       = (string) ( $policyConfig['custom_css_class'] ?? '' );
+	$showVersionHistory = true === ( $policyConfig['show_version_history'] ?? true );
+	$showLocaleSwitcher = true === ( $policyConfig['show_locale_switcher'] ?? true );
+	$activeVersion     = (string) $policy->version;
+	$publishedAt       = optional( $policy->published_at )->translatedFormat( 'F j, Y' );
+@endphp
+
+<div
+	class="privacy-policy {{ $customClass }}"
+	data-privacy-policy
+	data-policy-version="{{ $policy->version }}"
+	data-policy-regulation="{{ $policy->regulation ?? 'general' }}"
+	data-policy-locale="{{ $policy->locale }}"
+>
+	<style>
+		.privacy-policy {
+			--privacy-policy-max-width: 56rem;
+			--privacy-policy-toc-bg: var(--privacy-toc-bg, #f8fafc);
+			--privacy-policy-toc-text: var(--privacy-toc-text, #1f2937);
+			--privacy-policy-body-text: var(--privacy-body-text, #111827);
+			--privacy-policy-link: var(--privacy-link, #1d4ed8);
+		}
+		@media ( prefers-color-scheme: dark ) {
+			.privacy-policy {
+				--privacy-policy-toc-bg: var(--privacy-toc-bg-dark, #1f2937);
+				--privacy-policy-toc-text: var(--privacy-toc-text-dark, #f9fafb);
+				--privacy-policy-body-text: var(--privacy-body-text-dark, #f3f4f6);
+				--privacy-policy-link: var(--privacy-link-dark, #93c5fd);
+			}
+		}
+		.privacy-policy__layout {
+			max-width: var(--privacy-policy-max-width);
+			margin: 0 auto;
+			padding: 1.5rem;
+			color: var(--privacy-policy-body-text);
+		}
+		.privacy-policy__layout a { color: var(--privacy-policy-link); }
+		.privacy-policy__toc {
+			background: var(--privacy-policy-toc-bg);
+			color: var(--privacy-policy-toc-text);
+			border-radius: 0.5rem;
+			padding: 1rem 1.25rem;
+			margin-bottom: 1.5rem;
+		}
+		.privacy-policy__toc ol { list-style: decimal; padding-left: 1.25rem; }
+		.privacy-policy__meta { display: flex; gap: 1rem; flex-wrap: wrap; font-size: 0.875rem; opacity: 0.8; }
+		.privacy-policy__body { line-height: 1.6; }
+		.privacy-policy__body h1, .privacy-policy__body h2, .privacy-policy__body h3 {
+			scroll-margin-top: 4rem;
+		}
+		@media print {
+			.privacy-policy__toc, .privacy-policy__actions, .privacy-policy__history { display: none !important; }
+			.privacy-policy__layout { max-width: none; padding: 0; }
+			.privacy-policy a { text-decoration: none; color: inherit; }
+		}
+	</style>
+
+	<div class="privacy-policy__layout">
+		<header class="privacy-policy__header">
+			<h1 class="privacy-policy__title">
+				{{ __( 'Privacy Policy' ) }}
+			</h1>
+
+			<div class="privacy-policy__meta">
+				<span>{{ __( 'Version' ) }}: <strong>{{ $activeVersion }}</strong></span>
+				@if($publishedAt)
+					<span>{{ __( 'Last updated' ) }}: <strong>{{ $publishedAt }}</strong></span>
+				@endif
+				@if($policy->regulation)
+					<span>{{ __( 'Regulation' ) }}: <strong>{{ strtoupper( $policy->regulation ) }}</strong></span>
+				@endif
+			</div>
+
+			<div class="privacy-policy__actions" style="margin-top: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+				<button
+					type="button"
+					onclick="window.print();"
+					class="btn btn-sm btn-outline"
+					data-privacy-policy-print
+				>
+					{{ __( 'Print' ) }}
+				</button>
+
+				@if($showLocaleSwitcher && count( $availableLocales ) > 1)
+					<form method="GET" action="" style="display: flex; gap: 0.5rem; align-items: center;">
+						<label for="privacy-policy-locale" class="sr-only">{{ __( 'Language' ) }}</label>
+						<select id="privacy-policy-locale" name="locale" onchange="this.form.submit();" class="select select-sm">
+							@foreach($availableLocales as $availableLocale)
+								<option value="{{ $availableLocale }}" @selected( $availableLocale === $locale )>
+									{{ strtoupper( $availableLocale ) }}
+								</option>
+							@endforeach
+						</select>
+					</form>
+				@endif
+			</div>
+		</header>
+
+		@if( ! empty( $sections ))
+			<nav class="privacy-policy__toc" aria-label="{{ __( 'Table of contents' ) }}">
+				<h2 style="font-weight: 600; margin-bottom: 0.5rem;">
+					{{ __( 'On this page' ) }}
+				</h2>
+				<ol>
+					@foreach($sections as $section)
+						@continue($section['level'] > 3)
+						<li style="margin-left: {{ ( $section['level'] - 1 ) * 0.75 }}rem;">
+							<a href="#{{ $section['slug'] }}">
+								{{ $section['heading'] }}
+							</a>
+						</li>
+					@endforeach
+				</ol>
+			</nav>
+		@endif
+
+		<article class="privacy-policy__body prose prose-slate dark:prose-invert max-w-none">
+			{!! $html !!}
+		</article>
+
+		@if($showVersionHistory && $history->count() > 1)
+			<section class="privacy-policy__history" style="margin-top: 2rem;" aria-labelledby="privacy-policy-history-heading">
+				<h2 id="privacy-policy-history-heading" style="font-weight: 600; margin-bottom: 0.5rem;">
+					{{ __( 'Version history' ) }}
+				</h2>
+				<ul style="list-style: disc; padding-left: 1.25rem;">
+					@foreach($history as $entry)
+						<li>
+							@if($entry->version === $activeVersion)
+								<strong>
+									{{ $entry->version }}
+									@if($entry->active)
+										<span class="badge badge-success">{{ __( 'Current' ) }}</span>
+									@endif
+								</strong>
+								&middot; {{ optional( $entry->published_at )->translatedFormat( 'F j, Y' ) }}
+							@else
+								<a href="{{ route( 'privacy.policy.show-version', [ 'version' => $entry->version, 'locale' => $locale ] ) }}">
+									{{ $entry->version }}
+								</a>
+								&middot; {{ optional( $entry->published_at )->translatedFormat( 'F j, Y' ) }}
+							@endif
+						</li>
+					@endforeach
+				</ul>
+			</section>
+		@endif
+	</div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,8 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\Privacy\Http\Controllers\DataExportDownloadController;
 use ArtisanPackUI\Privacy\Http\Controllers\DataRequestVerificationController;
+use ArtisanPackUI\Privacy\Http\Controllers\PrivacyPolicyController;
+use ArtisanPackUI\Privacy\Http\Controllers\ReconsentController;
 use Illuminate\Support\Facades\Route;
 
 Route::get(
@@ -33,3 +35,22 @@ Route::get(
 	'/exports/{path}',
 	DataExportDownloadController::class,
 )->where( 'path', '.*' )->name( 'privacy.exports.download' );
+
+$policyPath = (string) config( 'artisanpack.privacy.policy.path', 'policy' );
+
+Route::get(
+	"/{$policyPath}",
+	[ PrivacyPolicyController::class, 'show' ],
+)->name( 'privacy.policy.show' );
+
+Route::get(
+	"/{$policyPath}/{version}",
+	[ PrivacyPolicyController::class, 'showVersion' ],
+)->where( 'version', '[A-Za-z0-9._\-]+' )->name( 'privacy.policy.show-version' );
+
+$reconsentPath = (string) config( 'artisanpack.privacy.policy.reconsent_path', 'reconsent' );
+
+Route::post(
+	"/{$reconsentPath}",
+	[ ReconsentController::class, 'store' ],
+)->middleware( 'throttle:privacy-verification' )->name( 'privacy.policy.reconsent' );

--- a/src/Events/PolicyReconsentGiven.php
+++ b/src/Events/PolicyReconsentGiven.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * PolicyReconsentGiven event — dispatched after a subject re-consents to
+ * the active privacy policy.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Events;
+
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fired by {@see \ArtisanPackUI\Privacy\Services\ReconsentService::grant()}.
+ *
+ * @since 1.0.0
+ */
+class PolicyReconsentGiven
+{
+	use Dispatchable;
+	use SerializesModels;
+
+	/**
+	 * @param PrivacyPolicy  $policy  Policy the subject just re-consented to.
+	 * @param Model          $subject Subject that re-consented.
+	 * @param Request|null   $request Originating request, when available.
+	 */
+	public function __construct(
+		public PrivacyPolicy $policy,
+		public Model $subject,
+		public ?Request $request = null,
+	) {
+	}
+}

--- a/src/Events/PolicyReconsentRequired.php
+++ b/src/Events/PolicyReconsentRequired.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * PolicyReconsentRequired event — dispatched when a subject is out of
+ * sync with the active privacy policy and must re-consent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Events;
+
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fired by {@see \ArtisanPackUI\Privacy\Services\ReconsentService::notifyRequired()}
+ * when consent state no longer matches the active policy version.
+ *
+ * @since 1.0.0
+ */
+class PolicyReconsentRequired
+{
+	use Dispatchable;
+	use SerializesModels;
+
+	/**
+	 * @param PrivacyPolicy   $policy  Policy whose version is now in effect.
+	 * @param Model|null      $subject Subject that needs to re-consent.
+	 * @param Request|null    $request Originating request, when available.
+	 */
+	public function __construct(
+		public PrivacyPolicy $policy,
+		public ?Model $subject = null,
+		public ?Request $request = null,
+	) {
+	}
+}

--- a/src/Http/Controllers/PrivacyPolicyController.php
+++ b/src/Http/Controllers/PrivacyPolicyController.php
@@ -137,9 +137,14 @@ class PrivacyPolicyController
 	}
 
 	/**
-	 * Resolves the active policy by stepping through three preferences:
-	 * the regulation matching the request, then a general policy, then
-	 * any active policy for the requested locale.
+	 * Resolves the active policy. Tries the regulation-specific row first
+	 * (in the requested locale, falling back to any locale of the same
+	 * regulation), then a general (regulation IS NULL) row in the requested
+	 * locale, then the general row in any locale.
+	 *
+	 * Importantly, the final fallback is the general policy — not any
+	 * active policy — so a GDPR visitor never lands on a CCPA policy
+	 * just because no general policy is published.
 	 *
 	 * @since 1.0.0
 	 *
@@ -151,21 +156,43 @@ class PrivacyPolicyController
 	protected function resolveActivePolicy( Request $request, string $locale ): ?PrivacyPolicy
 	{
 		$regulation = $this->resolveRegulation( $request );
-
-		$query = PrivacyPolicy::query()->active()->forLocale( $locale )->latestFirst();
+		$base       = PrivacyPolicy::query()->active()->latestFirst();
 
 		if ( null !== $regulation ) {
-			$match = ( clone $query )->forRegulation( $regulation )->first();
+			$specific = $this->firstForLocale(
+				( clone $base )->forRegulation( $regulation ),
+				$locale,
+			);
 
-			if ( $match instanceof PrivacyPolicy ) {
-				return $match;
+			if ( $specific instanceof PrivacyPolicy ) {
+				return $specific;
 			}
 		}
 
-		$general = ( clone $query )->forRegulation( null )->first();
+		return $this->firstForLocale(
+			( clone $base )->forRegulation( null ),
+			$locale,
+		);
+	}
 
-		if ( $general instanceof PrivacyPolicy ) {
-			return $general;
+	/**
+	 * Returns the first matching policy for the given locale, falling back
+	 * to the same query without the locale filter so a partially-translated
+	 * deployment still serves _something_ instead of 404ing.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Builder  $query   Pre-built query.
+	 * @param  string                                 $locale  Locale code.
+	 *
+	 * @return PrivacyPolicy|null
+	 */
+	protected function firstForLocale( $query, string $locale ): ?PrivacyPolicy
+	{
+		$localised = ( clone $query )->forLocale( $locale )->first();
+
+		if ( $localised instanceof PrivacyPolicy ) {
+			return $localised;
 		}
 
 		return $query->first();

--- a/src/Http/Controllers/PrivacyPolicyController.php
+++ b/src/Http/Controllers/PrivacyPolicyController.php
@@ -1,0 +1,222 @@
+<?php
+
+/**
+ * PrivacyPolicyController — public-facing privacy policy display.
+ *
+ * Handles the `GET /{prefix}/policy` and `GET /{prefix}/policy/{version}`
+ * routes registered by the package: resolves the active policy (or a
+ * specific version), renders its Markdown body as HTML, exposes the
+ * structured table of contents, and feeds the print-friendly Blade view.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Http\Controllers;
+
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Routes public privacy policy views.
+ *
+ * @since 1.0.0
+ */
+class PrivacyPolicyController
+{
+	/**
+	 * Shows the active policy for the resolved regulation/locale. When no
+	 * policy matches the resolved regulation, falls back to the general
+	 * (regulation = NULL) policy so the route always renders something
+	 * meaningful.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request (carries `?locale`).
+	 *
+	 * @throws NotFoundHttpException When no policy has ever been published.
+	 *
+	 * @return View
+	 */
+	public function show( Request $request ): View
+	{
+		$locale = $this->resolveLocale( $request );
+		$policy = $this->resolveActivePolicy( $request, $locale );
+
+		if ( ! $policy instanceof PrivacyPolicy ) {
+			throw new NotFoundHttpException( 'No active privacy policy has been published.' );
+		}
+
+		return $this->renderPolicy( $policy, $locale );
+	}
+
+	/**
+	 * Shows a specific historical policy version. Locale is honoured so
+	 * `/policy/1.2.0?locale=fr` resolves the same version in another
+	 * locale when one exists.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 * @param  string   $version Version string.
+	 *
+	 * @throws NotFoundHttpException When the version is unknown.
+	 *
+	 * @return View
+	 */
+	public function showVersion( Request $request, string $version ): View
+	{
+		$locale = $this->resolveLocale( $request );
+
+		$policy = PrivacyPolicy::query()
+			->forVersion( $version )
+			->forLocale( $locale )
+			->latestFirst()
+			->first();
+
+		if ( ! $policy instanceof PrivacyPolicy ) {
+			$policy = PrivacyPolicy::query()
+				->forVersion( $version )
+				->latestFirst()
+				->first();
+		}
+
+		if ( ! $policy instanceof PrivacyPolicy ) {
+			throw new NotFoundHttpException(
+				"No privacy policy with version [{$version}] exists.",
+			);
+		}
+
+		return $this->renderPolicy( $policy, $locale );
+	}
+
+	/**
+	 * Builds the shared view payload — kept here so {@see show()} and
+	 * {@see showVersion()} stay aligned.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PrivacyPolicy  $policy  Resolved policy.
+	 * @param  string         $locale  Resolved locale.
+	 *
+	 * @return View
+	 */
+	protected function renderPolicy( PrivacyPolicy $policy, string $locale ): View
+	{
+		$history = PrivacyPolicy::query()
+			->forRegulation( $policy->regulation )
+			->forLocale( $policy->locale )
+			->whereNotNull( 'published_at' )
+			->latestFirst()
+			->get();
+
+		$availableLocales = PrivacyPolicy::query()
+			->forRegulation( $policy->regulation )
+			->whereNotNull( 'published_at' )
+			->select( 'locale' )
+			->distinct()
+			->pluck( 'locale' )
+			->all();
+
+		return view( 'privacy::policy.show', [
+			'policy'           => $policy,
+			'html'             => $policy->renderHtml(),
+			'sections'         => $policy->tableOfContents(),
+			'history'          => $history,
+			'availableLocales' => $availableLocales,
+			'locale'           => $locale,
+		] );
+	}
+
+	/**
+	 * Resolves the active policy by stepping through three preferences:
+	 * the regulation matching the request, then a general policy, then
+	 * any active policy for the requested locale.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 * @param  string   $locale  Resolved locale.
+	 *
+	 * @return PrivacyPolicy|null
+	 */
+	protected function resolveActivePolicy( Request $request, string $locale ): ?PrivacyPolicy
+	{
+		$regulation = $this->resolveRegulation( $request );
+
+		$query = PrivacyPolicy::query()->active()->forLocale( $locale )->latestFirst();
+
+		if ( null !== $regulation ) {
+			$match = ( clone $query )->forRegulation( $regulation )->first();
+
+			if ( $match instanceof PrivacyPolicy ) {
+				return $match;
+			}
+		}
+
+		$general = ( clone $query )->forRegulation( null )->first();
+
+		if ( $general instanceof PrivacyPolicy ) {
+			return $general;
+		}
+
+		return $query->first();
+	}
+
+	/**
+	 * Resolves the regulation token applicable to the current request.
+	 * Honours the `?regulation` query string for previewing locales of
+	 * other regulations, falling back to the geolocated regulation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 *
+	 * @return string|null
+	 */
+	protected function resolveRegulation( Request $request ): ?string
+	{
+		$override = $request->query( 'regulation' );
+
+		if ( is_string( $override ) && '' !== $override ) {
+			return strtolower( $override );
+		}
+
+		$attribute = $request->attributes->get( 'privacy_regulation' );
+
+		if ( is_string( $attribute ) && '' !== $attribute ) {
+			return strtolower( $attribute );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolves the requested locale from the query string, falling back
+	 * to the app locale.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 *
+	 * @return string
+	 */
+	protected function resolveLocale( Request $request ): string
+	{
+		$query = $request->query( 'locale' );
+
+		if ( is_string( $query ) && '' !== $query ) {
+			return $query;
+		}
+
+		return (string) ( config( 'app.locale' ) ?? 'en' );
+	}
+}

--- a/src/Http/Controllers/ReconsentController.php
+++ b/src/Http/Controllers/ReconsentController.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * ReconsentController — records an authenticated user's re-consent.
+ *
+ * Handles the `POST /{prefix}/reconsent` endpoint registered by the
+ * package: validates the supplied policy version against the current
+ * active policy and persists the alignment through
+ * {@see \ArtisanPackUI\Privacy\Services\ReconsentService::grant()}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Http\Controllers;
+
+use ArtisanPackUI\Privacy\Services\ReconsentService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Persists re-consent submitted from the banner Livewire/React/Vue UI.
+ *
+ * @since 1.0.0
+ */
+class ReconsentController
+{
+	/**
+	 * Validates and stores the subject's re-consent.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request           $request   Incoming request.
+	 * @param  ReconsentService  $reconsent Service used to update consent records.
+	 *
+	 * @return Response
+	 */
+	public function store( Request $request, ReconsentService $reconsent ): Response
+	{
+		$data = $request->validate( [
+			'version'    => [ 'required', 'string', 'max:64' ],
+			'regulation' => [ 'nullable', 'string', 'max:32' ],
+			'redirect'   => [ 'nullable', 'string', 'max:2048' ],
+		] );
+
+		$policy = $reconsent->currentPolicy( $data['regulation'] ?? null );
+
+		if ( null === $policy || $policy->version !== $data['version'] ) {
+			return $this->respond( $request, false, [
+				'message' => __( 'The submitted policy version is no longer current.' ),
+			], 409 );
+		}
+
+		$subject = $request->user();
+
+		if ( ! $subject instanceof Model ) {
+			return $this->respond( $request, false, [
+				'message' => __( 'Authentication is required to re-consent.' ),
+			], 401 );
+		}
+
+		$reconsent->grant( $policy, $subject, $request );
+
+		if ( $request->expectsJson() ) {
+			return new JsonResponse( [
+				'ok'      => true,
+				'version' => $policy->version,
+			] );
+		}
+
+		$redirect = $data['redirect'] ?? $request->headers->get( 'referer' );
+
+		return redirect()->to(
+			is_string( $redirect ) && '' !== $redirect ? $redirect : '/',
+		);
+	}
+
+	/**
+	 * Returns a JSON response when the client expects JSON, or a redirect
+	 * back otherwise. Centralised so JSON shape stays consistent.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request                $request Incoming request.
+	 * @param  bool                   $ok      Outcome flag for the JSON payload.
+	 * @param  array<string, mixed>   $payload Additional JSON payload.
+	 * @param  int                    $status  HTTP status code.
+	 *
+	 * @return Response
+	 */
+	protected function respond( Request $request, bool $ok, array $payload, int $status ): Response
+	{
+		if ( $request->expectsJson() ) {
+			return new JsonResponse( array_merge( [ 'ok' => $ok ], $payload ), $status );
+		}
+
+		return back()->withErrors( $payload );
+	}
+}

--- a/src/Http/Controllers/ReconsentController.php
+++ b/src/Http/Controllers/ReconsentController.php
@@ -76,11 +76,44 @@ class ReconsentController
 			] );
 		}
 
-		$redirect = $data['redirect'] ?? $request->headers->get( 'referer' );
-
 		return redirect()->to(
-			is_string( $redirect ) && '' !== $redirect ? $redirect : '/',
+			$this->resolveSafeRedirect( $request, $data['redirect'] ?? null ),
 		);
+	}
+
+	/**
+	 * Resolves the post-success redirect, refusing any URL that points
+	 * off-host so a crafted form body or Referer header cannot turn the
+	 * reconsent endpoint into an open redirect after a successful
+	 * acceptance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request      $request  Incoming request.
+	 * @param  string|null  $supplied User-supplied redirect target.
+	 *
+	 * @return string
+	 */
+	protected function resolveSafeRedirect( Request $request, ?string $supplied ): string
+	{
+		foreach ( [ $supplied, $request->headers->get( 'referer' ) ] as $candidate ) {
+			if ( ! is_string( $candidate ) || '' === $candidate ) {
+				continue;
+			}
+
+			$parsed = parse_url( $candidate );
+
+			// Relative URLs (no scheme + no host) are always safe to honour.
+			if ( ! isset( $parsed['host'] ) && ! isset( $parsed['scheme'] ) ) {
+				return $candidate;
+			}
+
+			if ( isset( $parsed['host'] ) && $parsed['host'] === $request->getHost() ) {
+				return $candidate;
+			}
+		}
+
+		return '/';
 	}
 
 	/**

--- a/src/Http/Middleware/EnsureUpToDateConsent.php
+++ b/src/Http/Middleware/EnsureUpToDateConsent.php
@@ -7,9 +7,16 @@
  * Pairs with {@see \ArtisanPackUI\Privacy\Services\ReconsentService} to
  * detect when the active policy version no longer matches the consent
  * recorded for the request's subject. Sets a `privacy_reconsent_required`
- * request attribute (and a matching view variable) so the reconsent banner
- * Livewire/React/Vue components can render. Returns a redirect or 403
- * response once the grace period has elapsed.
+ * request attribute so the reconsent banner Livewire/React/Vue
+ * components can render. Returns a redirect or 403 response once the
+ * grace period has elapsed.
+ *
+ * The middleware does not call {@see \Illuminate\Support\Facades\View::share()}
+ * — that helper writes to a process-global bag that would leak between
+ * requests on Octane/Swoole/RoadRunner. The request attribute is
+ * per-request and safe; consumers can read it via
+ * `request()->attributes->get('privacy_reconsent_required')` in their
+ * layouts.
  *
  * Usage:
  *
@@ -27,10 +34,13 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Privacy\Http\Middleware;
 
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
 use ArtisanPackUI\Privacy\Services\ReconsentService;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\View;
+use Illuminate\Routing\Exceptions\UrlGenerationException;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -40,6 +50,28 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class EnsureUpToDateConsent
 {
+	/**
+	 * Session key used to dedupe the `PolicyReconsentRequired` event so
+	 * listeners (notifications, audit log) fire at most once per
+	 * session per policy version instead of once per request.
+	 *
+	 * @var string
+	 */
+	protected const NOTIFIED_SESSION_KEY = 'privacy.reconsent.notified_for';
+
+	/**
+	 * Route names that should never trigger the block — even when the
+	 * subject is out-of-date and the grace period has elapsed — because
+	 * the visitor needs to reach them to actually re-consent.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const BYPASS_ROUTE_NAMES = [
+		'privacy.policy.show',
+		'privacy.policy.show-version',
+		'privacy.policy.reconsent',
+	];
+
 	/**
 	 * @param ReconsentService $reconsent Service used to check policy alignment.
 	 */
@@ -61,7 +93,7 @@ class EnsureUpToDateConsent
 	{
 		$policy = $this->reconsent->currentPolicy();
 
-		if ( null === $policy || true !== (bool) $policy->requires_reconsent ) {
+		if ( ! $policy instanceof PrivacyPolicy || true !== (bool) $policy->requires_reconsent ) {
 			return $next( $request );
 		}
 
@@ -72,12 +104,9 @@ class EnsureUpToDateConsent
 		$request->attributes->set( 'privacy_reconsent_required', true );
 		$request->attributes->set( 'privacy_reconsent_policy', $policy );
 
-		View::share( 'privacyReconsentRequired', true );
-		View::share( 'privacyReconsentPolicy', $policy );
+		$this->notifyOnce( $request, $policy );
 
-		$this->reconsent->notifyRequired( $policy, null, $request );
-
-		if ( $this->reconsent->isBlocked() ) {
+		if ( $this->reconsent->isBlocked() && ! $this->isBypassRoute( $request ) ) {
 			return $this->buildBlockedResponse( $request );
 		}
 
@@ -85,8 +114,69 @@ class EnsureUpToDateConsent
 	}
 
 	/**
+	 * Fires `PolicyReconsentRequired` at most once per session per policy
+	 * version so listeners (logging, notifications) aren't woken on every
+	 * page load while the user is still inside the grace period.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request        $request Incoming request.
+	 * @param  PrivacyPolicy  $policy  Policy that triggered the requirement.
+	 *
+	 * @return void
+	 */
+	protected function notifyOnce( Request $request, PrivacyPolicy $policy ): void
+	{
+		$session = $request->hasSession() ? $request->session() : null;
+
+		if ( null === $session ) {
+			$this->reconsent->notifyRequired( $policy, null, $request );
+
+			return;
+		}
+
+		$signature = (string) $policy->getKey() . ':' . (string) $policy->version;
+
+		if ( $session->get( self::NOTIFIED_SESSION_KEY ) === $signature ) {
+			return;
+		}
+
+		$this->reconsent->notifyRequired( $policy, null, $request );
+		$session->put( self::NOTIFIED_SESSION_KEY, $signature );
+	}
+
+	/**
+	 * Returns true when the current request targets a route the visitor
+	 * needs to read or POST to in order to re-consent. The block check
+	 * skips these routes so the user always has a path forward.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 *
+	 * @return bool
+	 */
+	protected function isBypassRoute( Request $request ): bool
+	{
+		$name = $request->route()?->getName();
+
+		if ( null === $name ) {
+			return false;
+		}
+
+		$bypass = (array) config(
+			'artisanpack.privacy.policy.bypass_routes',
+			self::BYPASS_ROUTE_NAMES,
+		);
+
+		return in_array( $name, $bypass, true );
+	}
+
+	/**
 	 * Builds the response served when the grace period has elapsed and
-	 * `block_on_no_reconsent` is enabled.
+	 * `block_on_no_reconsent` is enabled. Falls back to the configured
+	 * abort status when the redirect target can't be resolved (e.g. the
+	 * consumer disabled the package's built-in routes).
 	 *
 	 * @since 1.0.0
 	 *
@@ -100,11 +190,11 @@ class EnsureUpToDateConsent
 		$status = (int) ( $config['status'] ?? 403 );
 		$route  = $config['redirect_route'] ?? 'privacy.policy.show';
 
-		if ( is_string( $route ) && '' !== $route ) {
-			$url = (string) route( $route );
-
-			if ( ! str_starts_with( (string) $request->path(), trim( parse_url( $url, PHP_URL_PATH ) ?: '/', '/' ) ) ) {
-				return redirect()->to( $url );
+		if ( is_string( $route ) && '' !== $route && RouteFacade::has( $route ) ) {
+			try {
+				return redirect()->to( (string) route( $route ) );
+			} catch ( UrlGenerationException | InvalidArgumentException ) {
+				// Fall through to abort below.
 			}
 		}
 

--- a/src/Http/Middleware/EnsureUpToDateConsent.php
+++ b/src/Http/Middleware/EnsureUpToDateConsent.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * EnsureUpToDateConsent middleware — flags out-of-date consent and, once
+ * the grace period elapses, blocks the request.
+ *
+ * Pairs with {@see \ArtisanPackUI\Privacy\Services\ReconsentService} to
+ * detect when the active policy version no longer matches the consent
+ * recorded for the request's subject. Sets a `privacy_reconsent_required`
+ * request attribute (and a matching view variable) so the reconsent banner
+ * Livewire/React/Vue components can render. Returns a redirect or 403
+ * response once the grace period has elapsed.
+ *
+ * Usage:
+ *
+ *   Route::middleware('privacy.reconsent')->group(...);
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Http\Middleware;
+
+use ArtisanPackUI\Privacy\Services\ReconsentService;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\View;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Route guard that flags / blocks subjects with out-of-date consent.
+ *
+ * @since 1.0.0
+ */
+class EnsureUpToDateConsent
+{
+	/**
+	 * @param ReconsentService $reconsent Service used to check policy alignment.
+	 */
+	public function __construct( protected ReconsentService $reconsent )
+	{
+	}
+
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 * @param  Closure  $next    Next middleware.
+	 *
+	 * @return Response
+	 */
+	public function handle( Request $request, Closure $next ): Response
+	{
+		$policy = $this->reconsent->currentPolicy();
+
+		if ( null === $policy || true !== (bool) $policy->requires_reconsent ) {
+			return $next( $request );
+		}
+
+		if ( $this->reconsent->isUpToDate() ) {
+			return $next( $request );
+		}
+
+		$request->attributes->set( 'privacy_reconsent_required', true );
+		$request->attributes->set( 'privacy_reconsent_policy', $policy );
+
+		View::share( 'privacyReconsentRequired', true );
+		View::share( 'privacyReconsentPolicy', $policy );
+
+		$this->reconsent->notifyRequired( $policy, null, $request );
+
+		if ( $this->reconsent->isBlocked() ) {
+			return $this->buildBlockedResponse( $request );
+		}
+
+		return $next( $request );
+	}
+
+	/**
+	 * Builds the response served when the grace period has elapsed and
+	 * `block_on_no_reconsent` is enabled.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Request  $request Incoming request.
+	 *
+	 * @return Response
+	 */
+	protected function buildBlockedResponse( Request $request ): Response
+	{
+		$config = (array) config( 'artisanpack.privacy.policy.blocked_response', [] );
+		$status = (int) ( $config['status'] ?? 403 );
+		$route  = $config['redirect_route'] ?? 'privacy.policy.show';
+
+		if ( is_string( $route ) && '' !== $route ) {
+			$url = (string) route( $route );
+
+			if ( ! str_starts_with( (string) $request->path(), trim( parse_url( $url, PHP_URL_PATH ) ?: '/', '/' ) ) ) {
+				return redirect()->to( $url );
+			}
+		}
+
+		abort( $status, (string) ( $config['message'] ?? 'You must accept the updated privacy policy to continue.' ) );
+	}
+}

--- a/src/Listeners/LogPolicyReconsent.php
+++ b/src/Listeners/LogPolicyReconsent.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * LogPolicyReconsent listener — logs re-consent prompts and acceptances.
+ *
+ * Default listener for {@see PolicyReconsentRequired} and
+ * {@see PolicyReconsentGiven}; subscribed via
+ * {@see \ArtisanPackUI\Privacy\PrivacyServiceProvider}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Listeners;
+
+use ArtisanPackUI\Privacy\Events\PolicyReconsentGiven;
+use ArtisanPackUI\Privacy\Events\PolicyReconsentRequired;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Writes re-consent lifecycle events to the configured logging channel.
+ *
+ * @since 1.0.0
+ */
+class LogPolicyReconsent
+{
+	/**
+	 * Handle a {@see PolicyReconsentRequired} event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PolicyReconsentRequired  $event Event payload.
+	 *
+	 * @return void
+	 */
+	public function handleRequired( PolicyReconsentRequired $event ): void
+	{
+		Log::info( 'privacy.policy.reconsent.required', [
+			'policy_version' => $event->policy->version,
+			'regulation'     => $event->policy->regulation,
+			'subject'        => $this->subjectReference( $event->subject ),
+		] );
+	}
+
+	/**
+	 * Handle a {@see PolicyReconsentGiven} event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PolicyReconsentGiven  $event Event payload.
+	 *
+	 * @return void
+	 */
+	public function handleGiven( PolicyReconsentGiven $event ): void
+	{
+		Log::info( 'privacy.policy.reconsent.given', [
+			'policy_version' => $event->policy->version,
+			'regulation'     => $event->policy->regulation,
+			'subject'        => $this->subjectReference( $event->subject ),
+		] );
+	}
+
+	/**
+	 * Builds the loggable subject reference. Returns null for guest events.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  mixed  $subject Subject seed.
+	 *
+	 * @return array{type: string, id: int|string}|null
+	 */
+	protected function subjectReference( mixed $subject ): ?array
+	{
+		if ( ! $subject instanceof \Illuminate\Database\Eloquent\Model ) {
+			return null;
+		}
+
+		return [
+			'type' => $subject->getMorphClass(),
+			'id'   => $subject->getKey(),
+		];
+	}
+}

--- a/src/Livewire/CookieBanner.php
+++ b/src/Livewire/CookieBanner.php
@@ -90,25 +90,61 @@ class CookieBanner extends Component
 	public array $selected = [];
 
 	/**
+	 * Extra CSS classes applied to the banner outer container.
+	 *
+	 * @var string
+	 */
+	public string $class = '';
+
+	/**
+	 * Extra CSS classes applied to the action buttons.
+	 *
+	 * @var string
+	 */
+	public string $buttonClasses = '';
+
+	/**
+	 * Overrides for the labels rendered inside the banner.
+	 *
+	 * Recognised keys: `title`, `description`, `accept_all`, `reject_all`,
+	 * `customise`, `save`, `required_badge`.
+	 *
+	 * @var array<string, string>
+	 */
+	public array $labels = [];
+
+	/**
 	 * Mount the component.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  string|null  $position   Override the configured banner position.
-	 * @param  string|null  $style      Override the configured banner style.
-	 * @param  array|null   $categories Explicit cookie-category map override.
+	 * @param  string|null            $position      Override the configured banner position.
+	 * @param  string|null            $style         Override the configured banner style.
+	 * @param  array|null             $categories    Explicit cookie-category map override.
+	 * @param  string|null            $class         Extra CSS classes on the outer container.
+	 * @param  string|null            $buttonClasses Extra CSS classes on the action buttons.
+	 * @param  array<string, string>  $labels        Label overrides for the rendered copy.
 	 *
 	 * @return void
 	 */
-	public function mount( ?string $position = null, ?string $style = null, ?array $categories = null ): void
-	{
+	public function mount(
+		?string $position = null,
+		?string $style = null,
+		?array $categories = null,
+		?string $class = null,
+		?string $buttonClasses = null,
+		array $labels = [],
+	): void {
 		$ui = (array) config( 'artisanpack.privacy.ui.cookie_banner', [] );
 
-		$this->position   = $position ?? (string) ( $ui['position'] ?? 'bottom' );
-		$this->style      = $style ?? (string) ( $ui['style'] ?? 'bar' );
-		$this->categories = $categories ?? $this->resolveCategories();
-		$this->selected   = $this->previousSelections();
-		$this->visible    = ! $this->hasExistingConsent() || $this->hasExpiredConsent();
+		$this->position      = $position ?? (string) ( $ui['position'] ?? 'bottom' );
+		$this->style         = $style ?? (string) ( $ui['style'] ?? 'bar' );
+		$this->categories    = $categories ?? $this->resolveCategories();
+		$this->selected      = $this->previousSelections();
+		$this->visible       = ! $this->hasExistingConsent() || $this->hasExpiredConsent();
+		$this->class         = $class ?? (string) config( 'artisanpack.privacy.ui.custom_css_class', '' );
+		$this->buttonClasses = $buttonClasses ?? '';
+		$this->labels        = $labels;
 	}
 
 	/**

--- a/src/Livewire/PolicyReconsentBanner.php
+++ b/src/Livewire/PolicyReconsentBanner.php
@@ -116,6 +116,13 @@ class PolicyReconsentBanner extends Component
 	/**
 	 * Records the current actor's re-consent.
 	 *
+	 * Compares the policy version captured at mount time against the
+	 * version that is currently active and refuses the grant if they
+	 * differ — that way the user can never accidentally accept a newer
+	 * policy that was republished after the banner was rendered but
+	 * before they clicked. When the versions diverge, the banner
+	 * resets so the visitor sees the new policy on the next render.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param  ReconsentService  $reconsent Injected service.
@@ -124,20 +131,30 @@ class PolicyReconsentBanner extends Component
 	 */
 	public function accept( ReconsentService $reconsent ): void
 	{
-		$policy = $this->resolvePolicy();
-		$user   = Auth::user();
+		$current = $reconsent->currentPolicy( $this->regulation );
+		$user    = Auth::user();
 
-		if ( null === $policy || null === $user ) {
+		if ( null === $current || null === $user ) {
 			$this->visible = false;
 			return;
 		}
 
-		$reconsent->grant( $policy, $user, request() );
+		if ( $this->policyVersion !== $current->version ) {
+			// Policy was republished between mount and click. Re-render so
+			// the user sees the new version and consents to that instead.
+			$this->policyVersion = $current->version;
+			$this->visible       = true;
 
-		$this->visible       = false;
-		$this->policyVersion = $policy->version;
+			$this->dispatch( 'privacy:reconsent-stale', version: $current->version );
 
-		$this->dispatch( 'privacy:reconsent-given', version: $policy->version );
+			return;
+		}
+
+		$reconsent->grant( $current, $user, request() );
+
+		$this->visible = false;
+
+		$this->dispatch( 'privacy:reconsent-given', version: $current->version );
 	}
 
 	/**

--- a/src/Livewire/PolicyReconsentBanner.php
+++ b/src/Livewire/PolicyReconsentBanner.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * PolicyReconsentBanner Livewire component — surfaces the re-consent prompt
+ * when the active privacy policy has been updated.
+ *
+ * Mount the component once, anywhere in the application's main layout:
+ *
+ *   <livewire:privacy-policy-reconsent-banner />
+ *
+ * Honours the optional `policy` prop for explicit injection (useful for
+ * tests) and the configured `class`, `buttonClasses`, and `labels` props
+ * so applications can theme the banner without publishing the view.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Livewire;
+
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use ArtisanPackUI\Privacy\Services\ReconsentService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+/**
+ * Re-consent prompt rendered on every page until the user accepts the new policy.
+ *
+ * @since 1.0.0
+ */
+class PolicyReconsentBanner extends Component
+{
+	/**
+	 * Optional CSS class applied to the outer container.
+	 *
+	 * @var string
+	 */
+	public string $class = '';
+
+	/**
+	 * Optional CSS class applied to action buttons.
+	 *
+	 * @var string
+	 */
+	public string $buttonClasses = '';
+
+	/**
+	 * Overrides for the labels displayed in the banner.
+	 *
+	 * Recognised keys: `title`, `description`, `accept`, `review`, `dismiss`.
+	 *
+	 * @var array<string, string>
+	 */
+	public array $labels = [];
+
+	/**
+	 * Optional override for the regulation key used to resolve the policy.
+	 *
+	 * @var string|null
+	 */
+	public ?string $regulation = null;
+
+	/**
+	 * The version of the policy currently being prompted on.
+	 *
+	 * @var string|null
+	 */
+	#[Locked]
+	public ?string $policyVersion = null;
+
+	/**
+	 * Whether the banner is visible. Set to false once the user accepts
+	 * or dismisses (within the grace period).
+	 *
+	 * @var bool
+	 */
+	public bool $visible = true;
+
+	/**
+	 * Mount the component.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null            $regulation     Regulation override.
+	 * @param  string|null            $class          Outer class override.
+	 * @param  string|null            $buttonClasses  Button class override.
+	 * @param  array<string, string>  $labels         Label overrides.
+	 *
+	 * @return void
+	 */
+	public function mount(
+		?string $regulation = null,
+		?string $class = null,
+		?string $buttonClasses = null,
+		array $labels = [],
+	): void {
+		$this->regulation    = $regulation;
+		$this->class         = $class ?? '';
+		$this->buttonClasses = $buttonClasses ?? '';
+		$this->labels        = $labels;
+
+		$policy              = $this->resolvePolicy();
+		$this->policyVersion = $policy?->version;
+		$this->visible       = null !== $policy;
+	}
+
+	/**
+	 * Records the current actor's re-consent.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ReconsentService  $reconsent Injected service.
+	 *
+	 * @return void
+	 */
+	public function accept( ReconsentService $reconsent ): void
+	{
+		$policy = $this->resolvePolicy();
+		$user   = Auth::user();
+
+		if ( null === $policy || null === $user ) {
+			$this->visible = false;
+			return;
+		}
+
+		$reconsent->grant( $policy, $user, request() );
+
+		$this->visible       = false;
+		$this->policyVersion = $policy->version;
+
+		$this->dispatch( 'privacy:reconsent-given', version: $policy->version );
+	}
+
+	/**
+	 * Dismisses the banner for the current request only — used while the
+	 * grace period is still open so the user can finish what they were
+	 * doing before re-consenting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function dismiss(): void
+	{
+		$this->visible = false;
+
+		$this->dispatch( 'privacy:reconsent-dismissed' );
+	}
+
+	/**
+	 * Returns the active policy that triggered the prompt, or null when no
+	 * re-consent is currently required.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return PrivacyPolicy|null
+	 */
+	#[Computed]
+	public function policy(): ?PrivacyPolicy
+	{
+		return $this->resolvePolicy();
+	}
+
+	/**
+	 * Renders the component view.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'privacy::livewire.policy-reconsent-banner' );
+	}
+
+	/**
+	 * Resolves the active policy through {@see ReconsentService}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return PrivacyPolicy|null
+	 */
+	protected function resolvePolicy(): ?PrivacyPolicy
+	{
+		$reconsent = app( ReconsentService::class );
+
+		$policy = $reconsent->currentPolicy( $this->regulation );
+
+		if ( null === $policy || $reconsent->isUpToDate( Auth::user(), $this->regulation ) ) {
+			return null;
+		}
+
+		return $policy;
+	}
+}

--- a/src/Models/Consent.php
+++ b/src/Models/Consent.php
@@ -34,6 +34,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property string                           $category
  * @property bool                             $granted
  * @property string|null                      $regulation
+ * @property string|null                      $policy_version
  * @property string|null                      $ip_address
  * @property string|null                      $user_agent
  * @property array|null                       $metadata
@@ -69,6 +70,7 @@ class Consent extends Model
 		'category',
 		'granted',
 		'regulation',
+		'policy_version',
 		'ip_address',
 		'user_agent',
 		'metadata',

--- a/src/Models/PrivacyPolicy.php
+++ b/src/Models/PrivacyPolicy.php
@@ -19,6 +19,9 @@ use ArtisanPackUI\Privacy\Database\Factories\PrivacyPolicyFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 /**
  * Eloquent model for the `privacy_policies` table.
@@ -31,7 +34,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property array|null                       $sections
  * @property bool                             $active
  * @property bool                             $requires_reconsent
- * @property \Illuminate\Support\Carbon|null  $published_at
+ * @property Carbon|null  $published_at
  * @property int|null                         $created_by
  *
  * @package    ArtisanPack_UI
@@ -113,6 +116,140 @@ class PrivacyPolicy extends Model
 	public function scopeForLocale( Builder $query, string $locale ): Builder
 	{
 		return $query->where( 'locale', $locale );
+	}
+
+	/**
+	 * Scope: ordered most-recent-version first using {@see versionSortKey()}
+	 * so semantic versions like `1.10.0` correctly outrank `1.9.0`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder  $query  Query builder.
+	 *
+	 * @return Builder
+	 */
+	public function scopeLatestFirst( Builder $query ): Builder
+	{
+		return $query->orderByDesc( 'published_at' )->orderByDesc( 'id' );
+	}
+
+	/**
+	 * Scope: limit to a specific version string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Builder  $query   Query builder.
+	 * @param  string   $version Version string (e.g. `1.2.0`).
+	 *
+	 * @return Builder
+	 */
+	public function scopeForVersion( Builder $query, string $version ): Builder
+	{
+		return $query->where( 'version', $version );
+	}
+
+	/**
+	 * Marks this policy active, replacing the previously-active record for
+	 * the same regulation/locale. Wrapped in a transaction so the swap is
+	 * atomic — callers can rely on `PrivacyPolicy::active()->first()`
+	 * returning the new row immediately after this method returns.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return self
+	 */
+	public function publish(): self
+	{
+		return DB::transaction( function (): self {
+			static::query()
+				->where( 'id', '!=', $this->getKey() )
+				->where( 'regulation', $this->regulation )
+				->where( 'locale', $this->locale )
+				->where( 'active', true )
+				->update( [ 'active' => false ] );
+
+			$this->forceFill( [
+				'active'       => true,
+				'published_at' => $this->published_at ?? Carbon::now(),
+			] )->save();
+
+			return $this;
+		} );
+	}
+
+	/**
+	 * Marks the policy inactive without removing it. Historical versions
+	 * remain queryable via {@see scopeForVersion()}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return self
+	 */
+	public function unpublish(): self
+	{
+		$this->forceFill( [ 'active' => false ] )->save();
+
+		return $this;
+	}
+
+	/**
+	 * Renders the Markdown body as HTML using Laravel's commonmark wrapper.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function renderHtml(): string
+	{
+		return Str::markdown( (string) $this->content );
+	}
+
+	/**
+	 * Returns the structured table of contents (heading/slug/level array).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array{heading: string, slug: string, level: int}>
+	 */
+	public function tableOfContents(): array
+	{
+		$sections = $this->sections;
+
+		if ( is_array( $sections ) && [] !== $sections ) {
+			return $sections;
+		}
+
+		return ( new \ArtisanPackUI\Privacy\Services\PrivacyPolicyGenerator() )
+			->extractSections( (string) $this->content );
+	}
+
+	/**
+	 * Returns a sortable key for the policy's version string. Two- or
+	 * three-segment semver-style strings are zero-padded so lexical sorts
+	 * are correct (`1.10.0` → `0001.0010.0000`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function versionSortKey(): string
+	{
+		$parts = preg_split( '/[\.\-+]/', (string) $this->version ) ?: [];
+		$parts = array_slice( $parts, 0, 3 );
+
+		while ( count( $parts ) < 3 ) {
+			$parts[] = '0';
+		}
+
+		return implode( '.', array_map(
+			static fn ( string $part ): string => str_pad(
+				preg_replace( '/[^0-9]/', '', $part ) ?: '0',
+				4,
+				'0',
+				STR_PAD_LEFT,
+			),
+			$parts,
+		) );
 	}
 
 	/**

--- a/src/Models/PrivacyPolicy.php
+++ b/src/Models/PrivacyPolicy.php
@@ -119,8 +119,12 @@ class PrivacyPolicy extends Model
 	}
 
 	/**
-	 * Scope: ordered most-recent-version first using {@see versionSortKey()}
-	 * so semantic versions like `1.10.0` correctly outrank `1.9.0`.
+	 * Scope: ordered most-recent-published first, falling back to id for
+	 * ties (batch publishes or seeded fixtures).
+	 *
+	 * Note: this orders by `published_at`, not by semver. Operators that
+	 * publish out-of-order hotfixes to an older version line should set
+	 * `published_at` accordingly — the database has no semver awareness.
 	 *
 	 * @since 1.0.0
 	 *
@@ -154,6 +158,12 @@ class PrivacyPolicy extends Model
 	 * atomic — callers can rely on `PrivacyPolicy::active()->first()`
 	 * returning the new row immediately after this method returns.
 	 *
+	 * Persists the model first (so unsaved-model callers don't bypass the
+	 * deactivation step via a NULL primary key), then deactivates any
+	 * sibling that shares regulation+locale using `whereNull()` for
+	 * general policies — `WHERE regulation = NULL` is UNKNOWN and would
+	 * silently skip the swap.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @return self
@@ -161,17 +171,23 @@ class PrivacyPolicy extends Model
 	public function publish(): self
 	{
 		return DB::transaction( function (): self {
-			static::query()
-				->where( 'id', '!=', $this->getKey() )
-				->where( 'regulation', $this->regulation )
-				->where( 'locale', $this->locale )
-				->where( 'active', true )
-				->update( [ 'active' => false ] );
-
 			$this->forceFill( [
 				'active'       => true,
 				'published_at' => $this->published_at ?? Carbon::now(),
 			] )->save();
+
+			$query = static::query()
+				->where( 'id', '!=', $this->getKey() )
+				->where( 'locale', $this->locale )
+				->where( 'active', true );
+
+			if ( null === $this->regulation ) {
+				$query->whereNull( 'regulation' );
+			} else {
+				$query->where( 'regulation', $this->regulation );
+			}
+
+			$query->update( [ 'active' => false ] );
 
 			return $this;
 		} );
@@ -195,13 +211,21 @@ class PrivacyPolicy extends Model
 	/**
 	 * Renders the Markdown body as HTML using Laravel's commonmark wrapper.
 	 *
+	 * Forces commonmark to escape raw HTML and strip unsafe links so any
+	 * value smuggled through a template placeholder (company name from
+	 * config, admin-edited content) cannot land as stored XSS on the
+	 * public policy view.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @return string
 	 */
 	public function renderHtml(): string
 	{
-		return Str::markdown( (string) $this->content );
+		return Str::markdown( (string) $this->content, [
+			'html_input'         => 'escape',
+			'allow_unsafe_links' => false,
+		] );
 	}
 
 	/**
@@ -221,35 +245,6 @@ class PrivacyPolicy extends Model
 
 		return ( new \ArtisanPackUI\Privacy\Services\PrivacyPolicyGenerator() )
 			->extractSections( (string) $this->content );
-	}
-
-	/**
-	 * Returns a sortable key for the policy's version string. Two- or
-	 * three-segment semver-style strings are zero-padded so lexical sorts
-	 * are correct (`1.10.0` → `0001.0010.0000`).
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string
-	 */
-	public function versionSortKey(): string
-	{
-		$parts = preg_split( '/[\.\-+]/', (string) $this->version ) ?: [];
-		$parts = array_slice( $parts, 0, 3 );
-
-		while ( count( $parts ) < 3 ) {
-			$parts[] = '0';
-		}
-
-		return implode( '.', array_map(
-			static fn ( string $part ): string => str_pad(
-				preg_replace( '/[^0-9]/', '', $part ) ?: '0',
-				4,
-				'0',
-				STR_PAD_LEFT,
-			),
-			$parts,
-		) );
 	}
 
 	/**

--- a/src/PrivacyServiceProvider.php
+++ b/src/PrivacyServiceProvider.php
@@ -30,7 +30,10 @@ use ArtisanPackUI\Privacy\Events\DataBreach;
 use ArtisanPackUI\Privacy\Events\DataDeletionRequested;
 use ArtisanPackUI\Privacy\Events\DataExportRequested;
 use ArtisanPackUI\Privacy\Events\DataRectificationRequested;
+use ArtisanPackUI\Privacy\Events\PolicyReconsentGiven;
+use ArtisanPackUI\Privacy\Events\PolicyReconsentRequired;
 use ArtisanPackUI\Privacy\Listeners\LogConsentActivity;
+use ArtisanPackUI\Privacy\Listeners\LogPolicyReconsent;
 use ArtisanPackUI\Privacy\Listeners\NotifyAdminOfRequest;
 use ArtisanPackUI\Privacy\Listeners\NotifyDataBreach;
 use ArtisanPackUI\Privacy\Listeners\ProcessDataAccessRequest;
@@ -45,6 +48,7 @@ use ArtisanPackUI\Privacy\Livewire\Admin\DataRequestManager;
 use ArtisanPackUI\Privacy\Livewire\ConsentPreferences;
 use ArtisanPackUI\Privacy\Livewire\CookieBanner;
 use ArtisanPackUI\Privacy\Livewire\DataRequestForm;
+use ArtisanPackUI\Privacy\Livewire\PolicyReconsentBanner;
 use ArtisanPackUI\Privacy\Livewire\PrivacyDashboard;
 use ArtisanPackUI\Privacy\Livewire\VerifyDataRequest;
 use ArtisanPackUI\Privacy\Regulations\Ccpa;
@@ -59,6 +63,8 @@ use ArtisanPackUI\Privacy\Services\DataExportService;
 use ArtisanPackUI\Privacy\Services\DataRequestService;
 use ArtisanPackUI\Privacy\Services\GeoLocationService;
 use ArtisanPackUI\Privacy\Services\PersonalDataScanner;
+use ArtisanPackUI\Privacy\Services\PrivacyPolicyGenerator;
+use ArtisanPackUI\Privacy\Services\ReconsentService;
 use ArtisanPackUI\Privacy\Services\VerificationService;
 use ArtisanPackUI\Privacy\View\PrivacyDirectives;
 use Illuminate\Auth\Events\Login;
@@ -110,6 +116,12 @@ class PrivacyServiceProvider extends ServiceProvider
 		],
 		DataBreach::class => [
 			[ NotifyDataBreach::class, 'handle' ],
+		],
+		PolicyReconsentRequired::class => [
+			[ LogPolicyReconsent::class, 'handleRequired' ],
+		],
+		PolicyReconsentGiven::class => [
+			[ LogPolicyReconsent::class, 'handleGiven' ],
 		],
 		Login::class => [
 			[ SyncConsentOnLogin::class, 'handle' ],
@@ -176,6 +188,15 @@ class PrivacyServiceProvider extends ServiceProvider
 
 		$this->app->singleton( GeoLocationService::class, fn () => new GeoLocationService() );
 		$this->app->alias( GeoLocationService::class, 'privacy.geolocation' );
+
+		$this->app->singleton( PrivacyPolicyGenerator::class, fn () => new PrivacyPolicyGenerator() );
+		$this->app->alias( PrivacyPolicyGenerator::class, 'privacy.policy_generator' );
+
+		$this->app->singleton(
+			ReconsentService::class,
+			fn ( $app ) => new ReconsentService( $app->make( ConsentService::class ) ),
+		);
+		$this->app->alias( ReconsentService::class, 'privacy.reconsent' );
 	}
 
 	/**
@@ -266,6 +287,22 @@ class PrivacyServiceProvider extends ServiceProvider
 			$this->publishes( [
 				$adminLayout => resource_path( 'views/vendor/artisanpack-ui/privacy/admin/layout.blade.php' ),
 			], 'privacy-admin-layout' );
+		}
+
+		$policyTemplates = __DIR__ . '/../resources/templates/policies';
+
+		if ( is_dir( $policyTemplates ) ) {
+			$this->publishes( [
+				$policyTemplates => resource_path( 'views/vendor/artisanpack-ui/privacy/templates/policies' ),
+			], 'privacy-policy-templates' );
+		}
+
+		$cssFile = __DIR__ . '/../resources/css/privacy.css';
+
+		if ( is_file( $cssFile ) ) {
+			$this->publishes( [
+				$cssFile => resource_path( 'css/vendor/artisanpack-ui/privacy.css' ),
+			], 'privacy-css' );
 		}
 	}
 
@@ -465,6 +502,7 @@ class PrivacyServiceProvider extends ServiceProvider
 		$router->aliasMiddleware( 'privacy.consent', Http\Middleware\EnsureConsentGiven::class );
 		$router->aliasMiddleware( 'privacy.context', Http\Middleware\CheckCookieConsent::class );
 		$router->aliasMiddleware( 'privacy.geolocate', Http\Middleware\GeolocateUser::class );
+		$router->aliasMiddleware( 'privacy.reconsent', Http\Middleware\EnsureUpToDateConsent::class );
 	}
 
 	/**
@@ -554,6 +592,7 @@ class PrivacyServiceProvider extends ServiceProvider
 		\Livewire\Livewire::component( 'privacy-data-request-form', DataRequestForm::class );
 		\Livewire\Livewire::component( 'privacy-verify-data-request', VerifyDataRequest::class );
 		\Livewire\Livewire::component( 'privacy-dashboard', PrivacyDashboard::class );
+		\Livewire\Livewire::component( 'privacy-policy-reconsent-banner', PolicyReconsentBanner::class );
 		\Livewire\Livewire::component( 'privacy-admin-consent-manager', ConsentManager::class );
 		\Livewire\Livewire::component( 'privacy-admin-data-request-manager', DataRequestManager::class );
 		\Livewire\Livewire::component( 'privacy-admin-compliance-report', ComplianceReport::class );

--- a/src/Services/PrivacyPolicyGenerator.php
+++ b/src/Services/PrivacyPolicyGenerator.php
@@ -1,0 +1,344 @@
+<?php
+
+/**
+ * PrivacyPolicyGenerator — builds versioned PrivacyPolicy records from
+ * regulation-specific Markdown templates.
+ *
+ * The generator reads templates shipped with the package (and any overrides
+ * published to `resources/views/vendor/artisanpack-ui/privacy/templates/policies`),
+ * interpolates `{{placeholder}}` tokens against caller-supplied data merged
+ * with the package's configured company defaults, and persists a new
+ * {@see PrivacyPolicy} row whose `content` holds the raw Markdown and whose
+ * `sections` JSON holds the heading outline used by the table of contents.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Services;
+
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+/**
+ * Generates {@see PrivacyPolicy} records from Markdown templates.
+ *
+ * @since 1.0.0
+ */
+class PrivacyPolicyGenerator
+{
+	/**
+	 * Regulations the generator ships first-party templates for.
+	 *
+	 * @var array<int, string>
+	 */
+	public const SUPPORTED_REGULATIONS = [ 'gdpr', 'ccpa', 'lgpd', 'pipeda' ];
+
+	/**
+	 * Builds a {@see PrivacyPolicy} model from the resolved template and
+	 * persists it. The new policy is created in draft (`active = false`,
+	 * `published_at = null`); call {@see PrivacyPolicy::publish()} once it
+	 * has been reviewed.
+	 *
+	 * Recognised `$options` keys:
+	 * - `regulation` (string|null)  Template key. Defaults to general.
+	 * - `locale`     (string)        Locale code. Defaults to app locale.
+	 * - `version`    (string)        Semantic version string. Defaults to "1.0.0".
+	 * - `data`       (array)         Placeholder overrides.
+	 * - `created_by` (int|Model|null) Author for the audit trail.
+	 * - `activate`   (bool)          Publish + activate after creation.
+	 * - `requires_reconsent` (bool)  Force returning users to reconsent.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $options Generation options.
+	 *
+	 * @return PrivacyPolicy
+	 */
+	public function generate( array $options = [] ): PrivacyPolicy
+	{
+		$regulation = $this->resolveRegulation( $options['regulation'] ?? null );
+		$locale     = (string) ( $options['locale'] ?? config( 'app.locale', 'en' ) );
+		$version    = (string) ( $options['version'] ?? '1.0.0' );
+		$data       = $this->resolveData( (array) ( $options['data'] ?? [] ) );
+
+		$rawTemplate = $this->loadTemplate( $regulation, $locale );
+		$content     = $this->renderTemplate( $rawTemplate, $data );
+		$sections    = $this->extractSections( $content );
+
+		$policy = PrivacyPolicy::query()->create( [
+			'version'            => $version,
+			'regulation'         => $regulation,
+			'locale'             => $locale,
+			'content'            => $content,
+			'sections'           => $sections,
+			'active'             => false,
+			'requires_reconsent' => (bool) ( $options['requires_reconsent'] ?? false ),
+			'published_at'       => null,
+			'created_by'         => $this->resolveCreatedBy( $options['created_by'] ?? null ),
+		] );
+
+		if ( true === ( $options['activate'] ?? false ) ) {
+			$policy->publish();
+		}
+
+		return $policy->refresh();
+	}
+
+	/**
+	 * Renders a template string with caller-supplied data without touching
+	 * the database. Public so callers can preview before persisting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string                $template Markdown template body.
+	 * @param  array<string, mixed>  $data     Placeholder values.
+	 *
+	 * @return string
+	 */
+	public function renderTemplate( string $template, array $data ): string
+	{
+		$rendered = $this->renderBlockSections( $template, $data );
+
+		return $this->renderPlaceholders( $rendered, $data );
+	}
+
+	/**
+	 * Returns the raw Markdown template body for the given regulation/locale.
+	 * Falls back to English when a locale-specific template is missing.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null  $regulation Regulation key or null for the general template.
+	 * @param  string       $locale     Locale code.
+	 *
+	 * @throws RuntimeException When no template exists for the regulation.
+	 *
+	 * @return string
+	 */
+	public function loadTemplate( ?string $regulation, string $locale = 'en' ): string
+	{
+		$regulation = $this->resolveRegulation( $regulation );
+		$candidates = $this->templateCandidates( $regulation, $locale );
+
+		foreach ( $candidates as $candidate ) {
+			if ( is_file( $candidate ) ) {
+				$contents = file_get_contents( $candidate );
+
+				if ( false !== $contents ) {
+					return $contents;
+				}
+			}
+		}
+
+		throw new RuntimeException(
+			"No privacy policy template found for regulation [{$regulation}] (locale: {$locale}).",
+		);
+	}
+
+	/**
+	 * Returns the structured outline (`heading`/`slug`/`level`) for a
+	 * Markdown document — used both to populate `PrivacyPolicy::$sections`
+	 * and to drive the table of contents on the display view.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $markdown Rendered Markdown.
+	 *
+	 * @return array<int, array{heading: string, slug: string, level: int}>
+	 */
+	public function extractSections( string $markdown ): array
+	{
+		$sections = [];
+		$lines    = preg_split( '/\R/u', $markdown ) ?: [];
+
+		foreach ( $lines as $line ) {
+			if ( 1 !== preg_match( '/^(#{1,6})\s+(.+)$/u', trim( $line ), $matches ) ) {
+				continue;
+			}
+
+			$level   = strlen( $matches[1] );
+			$heading = trim( $matches[2] );
+
+			$sections[] = [
+				'heading' => $heading,
+				'slug'    => Str::slug( $heading ),
+				'level'   => $level,
+			];
+		}
+
+		return $sections;
+	}
+
+	/**
+	 * Returns the candidate template paths in priority order, allowing
+	 * application overrides published to `resources/views/vendor/...` to
+	 * supersede the package defaults.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string  $regulation Regulation key (or `general`).
+	 * @param  string  $locale     Locale code.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function templateCandidates( string $regulation, string $locale ): array
+	{
+		$packageBase   = __DIR__ . '/../../resources/templates/policies';
+		$publishedBase = function_exists( 'resource_path' )
+			? resource_path( 'views/vendor/artisanpack-ui/privacy/templates/policies' )
+			: $packageBase;
+
+		$candidates = [];
+
+		foreach ( [ $publishedBase, $packageBase ] as $base ) {
+			$candidates[] = "{$base}/{$regulation}.{$locale}.md";
+			$candidates[] = "{$base}/{$regulation}.md";
+		}
+
+		return $candidates;
+	}
+
+	/**
+	 * Normalises the supplied regulation key. Unknown keys collapse to
+	 * `general` so callers can pass user-supplied input safely.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null  $regulation Raw regulation key.
+	 *
+	 * @return string
+	 */
+	protected function resolveRegulation( ?string $regulation ): string
+	{
+		if ( null === $regulation || '' === $regulation ) {
+			return 'general';
+		}
+
+		$normalised = strtolower( $regulation );
+
+		if ( 'general' === $normalised ) {
+			return 'general';
+		}
+
+		return in_array( $normalised, self::SUPPORTED_REGULATIONS, true )
+			? $normalised
+			: 'general';
+	}
+
+	/**
+	 * Merges caller-supplied placeholders with the package's configured
+	 * company/DPO defaults.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed>  $data Caller overrides.
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function resolveData( array $data ): array
+	{
+		$defaults = [
+			'company_name'           => (string) config( 'artisanpack.privacy.breach.organization.name', config( 'app.name', 'Our organization' ) ),
+			'company_email'          => (string) config( 'artisanpack.privacy.breach.organization.contact', config( 'artisanpack.privacy.data_requests.admin_email', '' ) ),
+			'company_address'        => (string) config( 'artisanpack.privacy.breach.organization.address', '' ),
+			'company_website'        => (string) config( 'artisanpack.privacy.breach.organization.website', config( 'app.url', '' ) ),
+			'dpo_email'              => (string) config( 'artisanpack.privacy.breach.dpo.email', '' ),
+			'dpo_phone'              => (string) config( 'artisanpack.privacy.breach.dpo.phone', '' ),
+			'effective_date'         => Carbon::now()->toFormattedDateString(),
+			'retention_account_days' => (string) (int) config( 'artisanpack.privacy.policy.retention_account_days', 90 ),
+		];
+
+		return array_merge( $defaults, $data );
+	}
+
+	/**
+	 * Strips conditional `{{#key}}…{{/key}}` blocks whose value is empty,
+	 * keeping the inner content when the value is truthy. Run before
+	 * placeholder substitution so empty defaults vanish cleanly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string                $template Raw template body.
+	 * @param  array<string, mixed>  $data     Placeholder values.
+	 *
+	 * @return string
+	 */
+	protected function renderBlockSections( string $template, array $data ): string
+	{
+		return (string) preg_replace_callback(
+			'/{{#([a-zA-Z0-9_]+)}}(.*?){{\/\1}}/s',
+			static function ( array $matches ) use ( $data ): string {
+				$value = $data[ $matches[1] ] ?? null;
+
+				if ( null === $value || '' === $value || false === $value ) {
+					return '';
+				}
+
+				return $matches[2];
+			},
+			$template,
+		);
+	}
+
+	/**
+	 * Substitutes `{{placeholder}}` tokens with their corresponding values.
+	 * Unknown placeholders are left intact so reviewers can spot them.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string                $template Pre-rendered template.
+	 * @param  array<string, mixed>  $data     Placeholder values.
+	 *
+	 * @return string
+	 */
+	protected function renderPlaceholders( string $template, array $data ): string
+	{
+		return (string) preg_replace_callback(
+			'/{{\s*([a-zA-Z0-9_]+)\s*}}/',
+			static function ( array $matches ) use ( $data ): string {
+				$key = $matches[1];
+
+				if ( ! array_key_exists( $key, $data ) ) {
+					return $matches[0];
+				}
+
+				return (string) $data[ $key ];
+			},
+			$template,
+		);
+	}
+
+	/**
+	 * Resolves the `created_by` value down to a user identifier.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  int|Model|null  $createdBy Author seed.
+	 *
+	 * @return int|null
+	 */
+	protected function resolveCreatedBy( mixed $createdBy ): ?int
+	{
+		if ( $createdBy instanceof Model ) {
+			$key = $createdBy->getKey();
+
+			return is_numeric( $key ) ? (int) $key : null;
+		}
+
+		if ( is_numeric( $createdBy ) ) {
+			return (int) $createdBy;
+		}
+
+		return null;
+	}
+}

--- a/src/Services/ReconsentService.php
+++ b/src/Services/ReconsentService.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * ReconsentService — detects out-of-date consent and orchestrates the
+ * re-consent workflow.
+ *
+ * Compares the most recent active policy that flips
+ * `requires_reconsent = true` against the policy version a subject has
+ * already consented under (recorded on `privacy_consents.policy_version`).
+ * Exposes helpers to grant re-consent, record the event, and apply the
+ * configured grace period before the application blocks the user.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Services;
+
+use ArtisanPackUI\Privacy\Events\PolicyReconsentGiven;
+use ArtisanPackUI\Privacy\Events\PolicyReconsentRequired;
+use ArtisanPackUI\Privacy\Models\Consent;
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Coordinates re-consent comparisons and updates.
+ *
+ * @since 1.0.0
+ */
+class ReconsentService
+{
+	/**
+	 * @param ConsentService $consents Inner consent service used to read state.
+	 */
+	public function __construct( protected ConsentService $consents )
+	{
+	}
+
+	/**
+	 * Returns the active policy that the application should be checking
+	 * consent against, or null when no policy has been published.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null  $regulation Regulation key (matches NULL for general).
+	 * @param  string|null  $locale     Optional locale to prefer.
+	 *
+	 * @return PrivacyPolicy|null
+	 */
+	public function currentPolicy( ?string $regulation = null, ?string $locale = null ): ?PrivacyPolicy
+	{
+		$query = PrivacyPolicy::query()
+			->active()
+			->forRegulation( $regulation )
+			->latestFirst();
+
+		if ( is_string( $locale ) && '' !== $locale ) {
+			$localised = ( clone $query )->forLocale( $locale )->first();
+
+			if ( $localised instanceof PrivacyPolicy ) {
+				return $localised;
+			}
+		}
+
+		return $query->first();
+	}
+
+	/**
+	 * Returns true when the subject's consent records are still aligned
+	 * with the current active policy (or no current policy exists).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model|null   $user       Subject, or null for the current actor.
+	 * @param  string|null  $regulation Regulation override.
+	 *
+	 * @return bool
+	 */
+	public function isUpToDate( ?Model $user = null, ?string $regulation = null ): bool
+	{
+		$policy = $this->currentPolicy( $regulation );
+
+		if ( ! $policy instanceof PrivacyPolicy || true !== (bool) $policy->requires_reconsent ) {
+			return true;
+		}
+
+		$subject = $user ?? Auth::user();
+
+		if ( ! $subject instanceof Model ) {
+			return $this->cookieVersionMatches( $policy );
+		}
+
+		$latest = Consent::query()
+			->where( 'consentable_type', $subject->getMorphClass() )
+			->where( 'consentable_id', $subject->getKey() )
+			->orderByDesc( 'created_at' )
+			->first();
+
+		if ( ! $latest instanceof Consent ) {
+			return false;
+		}
+
+		return $latest->policy_version === $policy->version;
+	}
+
+	/**
+	 * Returns true when a subject needs to re-consent AND is no longer
+	 * within the configured grace period.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  Model|null   $user       Subject, or null for the current actor.
+	 * @param  string|null  $regulation Regulation override.
+	 *
+	 * @return bool
+	 */
+	public function isBlocked( ?Model $user = null, ?string $regulation = null ): bool
+	{
+		if ( true !== (bool) config( 'artisanpack.privacy.policy.block_on_no_reconsent', false ) ) {
+			return false;
+		}
+
+		if ( $this->isUpToDate( $user, $regulation ) ) {
+			return false;
+		}
+
+		$policy = $this->currentPolicy( $regulation );
+
+		if ( ! $policy instanceof PrivacyPolicy ) {
+			return false;
+		}
+
+		$gracePeriodDays = (int) config( 'artisanpack.privacy.policy.reconsent_grace_period_days', 30 );
+
+		if ( $gracePeriodDays <= 0 ) {
+			return true;
+		}
+
+		$reference = $policy->published_at instanceof Carbon
+			? $policy->published_at->copy()
+			: Carbon::now();
+
+		return Carbon::now()->greaterThan( $reference->addDays( $gracePeriodDays ) );
+	}
+
+	/**
+	 * Records the subject's re-consent to the supplied policy. Updates
+	 * every active consent record's `policy_version` so subsequent
+	 * comparisons return true.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PrivacyPolicy  $policy  Policy the subject just consented to.
+	 * @param  Model|null     $user    Subject; defaults to the current actor.
+	 * @param  Request|null   $request Source request for capture metadata.
+	 *
+	 * @return int Number of consent rows updated.
+	 */
+	public function grant( PrivacyPolicy $policy, ?Model $user = null, ?Request $request = null ): int
+	{
+		$subject = $user ?? Auth::user();
+
+		if ( ! $subject instanceof Model ) {
+			return 0;
+		}
+
+		$updated = Consent::query()
+			->where( 'consentable_type', $subject->getMorphClass() )
+			->where( 'consentable_id', $subject->getKey() )
+			->update( [
+				'policy_version' => $policy->version,
+				'updated_at'     => Carbon::now(),
+			] );
+
+		Event::dispatch( new PolicyReconsentGiven( $policy, $subject, $request ) );
+
+		return (int) $updated;
+	}
+
+	/**
+	 * Fires the "reconsent required" event so listeners (notifications,
+	 * audit log) can react. Idempotent — safe to call from middleware.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PrivacyPolicy  $policy  Policy that triggered the requirement.
+	 * @param  Model|null     $user    Subject; defaults to the current actor.
+	 * @param  Request|null   $request Originating request.
+	 *
+	 * @return void
+	 */
+	public function notifyRequired( PrivacyPolicy $policy, ?Model $user = null, ?Request $request = null ): void
+	{
+		$subject = $user ?? Auth::user();
+
+		Event::dispatch( new PolicyReconsentRequired( $policy, $subject, $request ) );
+	}
+
+	/**
+	 * Compares the cookie-stored policy version against the active one.
+	 * Used as the fallback for guests with no database identity.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  PrivacyPolicy  $policy Active policy.
+	 *
+	 * @return bool
+	 */
+	protected function cookieVersionMatches( PrivacyPolicy $policy ): bool
+	{
+		$cookie = $this->consents->getConsentCookie();
+
+		if ( ! is_array( $cookie ) || ! isset( $cookie['_policy_version'] ) ) {
+			return false;
+		}
+
+		return (string) $cookie['_policy_version'] === $policy->version;
+	}
+}

--- a/src/Services/ReconsentService.php
+++ b/src/Services/ReconsentService.php
@@ -59,20 +59,33 @@ class ReconsentService
 	 */
 	public function currentPolicy( ?string $regulation = null, ?string $locale = null ): ?PrivacyPolicy
 	{
-		$query = PrivacyPolicy::query()
-			->active()
-			->forRegulation( $regulation )
-			->latestFirst();
+		// Resolve the regulation in a way that honours both regulation-tagged
+		// and general (NULL) policies — callers that don't know the visitor's
+		// applicable regulation should still find the active GDPR/CCPA/LGPD/
+		// PIPEDA row instead of only matching `regulation IS NULL`.
+		$base = PrivacyPolicy::query()->active()->latestFirst();
 
-		if ( is_string( $locale ) && '' !== $locale ) {
-			$localised = ( clone $query )->forLocale( $locale )->first();
+		if ( is_string( $regulation ) && '' !== $regulation ) {
+			$specific = $this->firstForLocale(
+				( clone $base )->forRegulation( $regulation ),
+				$locale,
+			);
 
-			if ( $localised instanceof PrivacyPolicy ) {
-				return $localised;
+			if ( $specific instanceof PrivacyPolicy ) {
+				return $specific;
 			}
 		}
 
-		return $query->first();
+		$general = $this->firstForLocale(
+			( clone $base )->forRegulation( null ),
+			$locale,
+		);
+
+		if ( $general instanceof PrivacyPolicy ) {
+			return $general;
+		}
+
+		return $this->firstForLocale( $base, $locale );
 	}
 
 	/**
@@ -97,17 +110,32 @@ class ReconsentService
 		$subject = $user ?? Auth::user();
 
 		if ( ! $subject instanceof Model ) {
-			return $this->cookieVersionMatches( $policy );
+			// Guests have no stored policy_version; treat them as up-to-date
+			// here and let the cookie banner / first-touch flow capture the
+			// policy version when they make their initial choice.
+			return true;
 		}
 
-		$latest = Consent::query()
+		$consents = Consent::query()
 			->where( 'consentable_type', $subject->getMorphClass() )
-			->where( 'consentable_id', $subject->getKey() )
-			->orderByDesc( 'created_at' )
-			->first();
+			->where( 'consentable_id', $subject->getKey() );
+
+		if ( null !== $policy->regulation ) {
+			$consents->where( function ( $query ) use ( $policy ): void {
+				$query->where( 'regulation', $policy->regulation )
+					->orWhereNull( 'regulation' );
+			} );
+		}
+
+		$latest = $consents->orderByDesc( 'created_at' )->first();
 
 		if ( ! $latest instanceof Consent ) {
-			return false;
+			// A subject that has never consented is not "out of date" — they
+			// have never been asked. The cookie banner is responsible for
+			// capturing initial consent; we only fire re-consent for
+			// subjects who actually have a stored consent on an older
+			// policy version.
+			return true;
 		}
 
 		return $latest->policy_version === $policy->version;
@@ -174,13 +202,27 @@ class ReconsentService
 			return 0;
 		}
 
-		$updated = Consent::query()
+		// Scope the update to consents that actually belong to this policy's
+		// regulation (general policy = NULL regulation also matches NULL or
+		// any regulation row), and skip withdrawn rows so a re-consent
+		// doesn't accidentally re-stamp opted-out categories with the new
+		// policy version.
+		$consents = Consent::query()
 			->where( 'consentable_type', $subject->getMorphClass() )
 			->where( 'consentable_id', $subject->getKey() )
-			->update( [
-				'policy_version' => $policy->version,
-				'updated_at'     => Carbon::now(),
-			] );
+			->whereNull( 'withdrawn_at' );
+
+		if ( null !== $policy->regulation ) {
+			$consents->where( function ( $query ) use ( $policy ): void {
+				$query->where( 'regulation', $policy->regulation )
+					->orWhereNull( 'regulation' );
+			} );
+		}
+
+		$updated = $consents->update( [
+			'policy_version' => $policy->version,
+			'updated_at'     => Carbon::now(),
+		] );
 
 		Event::dispatch( new PolicyReconsentGiven( $policy, $subject, $request ) );
 
@@ -207,23 +249,26 @@ class ReconsentService
 	}
 
 	/**
-	 * Compares the cookie-stored policy version against the active one.
-	 * Used as the fallback for guests with no database identity.
+	 * Returns the first matching policy for the given locale, falling back
+	 * to the locale-agnostic query when no localised row exists.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  PrivacyPolicy  $policy Active policy.
+	 * @param  \Illuminate\Database\Eloquent\Builder  $query  Pre-built query.
+	 * @param  string|null                            $locale Optional locale.
 	 *
-	 * @return bool
+	 * @return PrivacyPolicy|null
 	 */
-	protected function cookieVersionMatches( PrivacyPolicy $policy ): bool
+	protected function firstForLocale( $query, ?string $locale ): ?PrivacyPolicy
 	{
-		$cookie = $this->consents->getConsentCookie();
+		if ( is_string( $locale ) && '' !== $locale ) {
+			$localised = ( clone $query )->forLocale( $locale )->first();
 
-		if ( ! is_array( $cookie ) || ! isset( $cookie['_policy_version'] ) ) {
-			return false;
+			if ( $localised instanceof PrivacyPolicy ) {
+				return $localised;
+			}
 		}
 
-		return (string) $cookie['_policy_version'] === $policy->version;
+		return $query->first();
 	}
 }

--- a/tests/Feature/Http/Controllers/PrivacyPolicyControllerTest.php
+++ b/tests/Feature/Http/Controllers/PrivacyPolicyControllerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+
+it( 'returns 404 when no active policy exists', function (): void {
+	$this->get( '/privacy/policy' )->assertNotFound();
+} );
+
+it( 'renders the active policy at GET /privacy/policy', function (): void {
+	$policy = PrivacyPolicy::factory()->active()->create( [
+		'version' => '1.0.0',
+		'content' => "# Acme Privacy Policy\n\nWelcome.",
+	] );
+
+	$this->get( '/privacy/policy' )
+		->assertOk()
+		->assertSee( 'Acme Privacy Policy' )
+		->assertSee( '1.0.0' );
+} );
+
+it( 'renders a specific policy version at GET /privacy/policy/{version}', function (): void {
+	PrivacyPolicy::factory()->create( [
+		'version'      => '1.0.0',
+		'content'      => '# Version One',
+		'published_at' => now()->subWeek(),
+	] );
+	PrivacyPolicy::factory()->active()->create( [
+		'version' => '1.1.0',
+		'content' => '# Version Two',
+	] );
+
+	$this->get( '/privacy/policy/1.0.0' )
+		->assertOk()
+		->assertSee( 'Version One' );
+} );
+
+it( 'returns 404 for unknown policy versions', function (): void {
+	PrivacyPolicy::factory()->active()->create( [ 'version' => '1.0.0' ] );
+
+	$this->get( '/privacy/policy/9.9.9' )->assertNotFound();
+} );
+
+it( 'prefers the regulation-specific policy when requested', function (): void {
+	PrivacyPolicy::factory()->active()->create( [
+		'regulation' => null,
+		'content'    => '# General',
+	] );
+	PrivacyPolicy::factory()->active()->create( [
+		'regulation' => 'gdpr',
+		'content'    => '# GDPR Specific',
+	] );
+
+	$this->get( '/privacy/policy?regulation=gdpr' )
+		->assertOk()
+		->assertSee( 'GDPR Specific' );
+} );

--- a/tests/Feature/Http/ReconsentRoutesTest.php
+++ b/tests/Feature/Http/ReconsentRoutesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\Consent;
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use ArtisanPackUI\Privacy\Services\ReconsentService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\Support\TestSubject;
+
+beforeEach( function (): void {
+	Schema::create( 'test_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'name' )->nullable();
+		$table->string( 'email' )->nullable();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'test_subjects' );
+} );
+
+it( 'accepts a valid reconsent submission as JSON', function (): void {
+	$subject = TestSubject::create();
+
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+
+	$policy = PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	$this->actingAs( $subject )
+		->postJson( '/privacy/reconsent', [ 'version' => '1.0.0' ] )
+		->assertOk()
+		->assertJson( [ 'ok' => true, 'version' => '1.0.0' ] );
+
+	expect( app( ReconsentService::class )->isUpToDate( $subject ) )->toBeTrue();
+} );
+
+it( 'returns 409 when the supplied version is no longer current', function (): void {
+	$subject = TestSubject::create();
+
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '2.0.0',
+	] );
+
+	$this->actingAs( $subject )
+		->postJson( '/privacy/reconsent', [ 'version' => '1.0.0' ] )
+		->assertStatus( 409 )
+		->assertJsonPath( 'ok', false );
+} );
+
+it( 'returns 401 for guests', function (): void {
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	$this->postJson( '/privacy/reconsent', [ 'version' => '1.0.0' ] )
+		->assertStatus( 401 );
+} );

--- a/tests/Feature/Http/ReconsentRoutesTest.php
+++ b/tests/Feature/Http/ReconsentRoutesTest.php
@@ -57,6 +57,50 @@ it( 'returns 409 when the supplied version is no longer current', function (): v
 		->assertJsonPath( 'ok', false );
 } );
 
+it( 'refuses to redirect off-host and falls back to /', function (): void {
+	$subject = TestSubject::create();
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	$response = $this->actingAs( $subject )
+		->withHeaders( [ 'Accept' => 'text/html' ] )
+		->post( '/privacy/reconsent', [
+			'version'  => '1.0.0',
+			'redirect' => 'https://evil.example/login',
+		] );
+
+	$response->assertRedirect( '/' );
+} );
+
+it( 'honours same-host redirects after a successful reconsent', function (): void {
+	$subject = TestSubject::create();
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	$response = $this->actingAs( $subject )
+		->withHeaders( [ 'Accept' => 'text/html' ] )
+		->post( '/privacy/reconsent', [
+			'version'  => '1.0.0',
+			'redirect' => '/account',
+		] );
+
+	$response->assertRedirect( '/account' );
+} );
+
 it( 'returns 401 for guests', function (): void {
 	PrivacyPolicy::factory()->active()->create( [
 		'requires_reconsent' => true,

--- a/tests/Feature/Livewire/PolicyReconsentBannerTest.php
+++ b/tests/Feature/Livewire/PolicyReconsentBannerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Livewire\PolicyReconsentBanner;
+use ArtisanPackUI\Privacy\Models\Consent;
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+use Tests\Support\TestSubject;
+
+beforeEach( function (): void {
+	Schema::create( 'test_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'name' )->nullable();
+		$table->string( 'email' )->nullable();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'test_subjects' );
+} );
+
+it( 'hides itself when no reconsent is required', function (): void {
+	PrivacyPolicy::factory()->active()->create( [ 'requires_reconsent' => false ] );
+
+	Livewire::test( PolicyReconsentBanner::class )
+		->assertSet( 'visible', false );
+} );
+
+it( 'shows when the active policy requires reconsent and the user is out-of-date', function (): void {
+	$subject = TestSubject::create();
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	Livewire::actingAs( $subject )
+		->test( PolicyReconsentBanner::class )
+		->assertSet( 'visible', true )
+		->assertSet( 'policyVersion', '1.0.0' );
+} );
+
+it( 'accepts the new policy and updates consent rows', function (): void {
+	$subject = TestSubject::create();
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	Livewire::actingAs( $subject )
+		->test( PolicyReconsentBanner::class )
+		->call( 'accept' )
+		->assertSet( 'visible', false )
+		->assertDispatched( 'privacy:reconsent-given' );
+
+	$consent = Consent::query()
+		->where( 'consentable_type', $subject->getMorphClass() )
+		->where( 'consentable_id', $subject->getKey() )
+		->firstOrFail();
+
+	expect( $consent->policy_version )->toBe( '1.0.0' );
+} );
+
+it( 'forwards mount-time customisation props', function (): void {
+	$subject = TestSubject::create();
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	Livewire::actingAs( $subject )
+		->test( PolicyReconsentBanner::class, [
+			'class'         => 'banner--xl',
+			'buttonClasses' => 'btn-xl',
+			'labels'        => [ 'accept' => 'Accept new version' ],
+		] )
+		->assertSet( 'class', 'banner--xl' )
+		->assertSet( 'buttonClasses', 'btn-xl' )
+		->assertSee( 'Accept new version' );
+} );

--- a/tests/Feature/Models/PrivacyPolicyPublishingTest.php
+++ b/tests/Feature/Models/PrivacyPolicyPublishingTest.php
@@ -75,9 +75,32 @@ it( 'falls back to extracting from content when sections are empty', function ()
 	expect( $policy->tableOfContents() )->toHaveCount( 2 );
 } );
 
-it( 'produces a sortable version key', function (): void {
-	$ten  = PrivacyPolicy::factory()->make( [ 'version' => '1.10.0' ] );
-	$nine = PrivacyPolicy::factory()->make( [ 'version' => '1.9.0' ] );
+it( 'deactivates the previously-active general policy on publish even when regulation is NULL', function (): void {
+	$old = PrivacyPolicy::factory()->active()->create( [
+		'regulation' => null,
+		'locale'     => 'en',
+		'version'    => '1.0.0',
+	] );
+	$new = PrivacyPolicy::factory()->create( [
+		'regulation' => null,
+		'locale'     => 'en',
+		'version'    => '1.1.0',
+		'active'     => false,
+	] );
 
-	expect( $ten->versionSortKey() > $nine->versionSortKey() )->toBeTrue();
+	$new->publish();
+
+	expect( $old->fresh()->active )->toBeFalse();
+	expect( $new->fresh()->active )->toBeTrue();
+} );
+
+it( 'sanitises raw HTML when rendering the policy body', function (): void {
+	$policy = PrivacyPolicy::factory()->create( [
+		'content' => "# Hello\n\n<script>alert(1)</script>\n",
+	] );
+
+	$html = $policy->renderHtml();
+
+	expect( $html )->not->toContain( '<script>' );
+	expect( $html )->toContain( 'alert(1)' );
 } );

--- a/tests/Feature/Models/PrivacyPolicyPublishingTest.php
+++ b/tests/Feature/Models/PrivacyPolicyPublishingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+
+it( 'replaces the previously active policy when publishing a new one', function (): void {
+	$oldPolicy = PrivacyPolicy::factory()->active()->create( [
+		'regulation' => 'gdpr',
+		'locale'     => 'en',
+		'version'    => '1.0.0',
+	] );
+
+	$newPolicy = PrivacyPolicy::factory()->create( [
+		'regulation' => 'gdpr',
+		'locale'     => 'en',
+		'version'    => '1.1.0',
+		'active'     => false,
+	] );
+
+	$newPolicy->publish();
+
+	expect( $oldPolicy->fresh()->active )->toBeFalse();
+	expect( $newPolicy->fresh()->active )->toBeTrue();
+	expect( $newPolicy->fresh()->published_at )->not->toBeNull();
+} );
+
+it( 'leaves policies for other regulations alone when publishing', function (): void {
+	$gdprPolicy = PrivacyPolicy::factory()->active()->create( [
+		'regulation' => 'gdpr',
+		'locale'     => 'en',
+		'version'    => '1.0.0',
+	] );
+
+	$ccpa = PrivacyPolicy::factory()->create( [
+		'regulation' => 'ccpa',
+		'locale'     => 'en',
+		'version'    => '1.0.0',
+		'active'     => false,
+	] );
+
+	$ccpa->publish();
+
+	expect( $gdprPolicy->fresh()->active )->toBeTrue();
+	expect( $ccpa->fresh()->active )->toBeTrue();
+} );
+
+it( 'renders Markdown content to HTML', function (): void {
+	$policy = PrivacyPolicy::factory()->create( [
+		'content' => "# Title\n\nBody text.",
+	] );
+
+	expect( $policy->renderHtml() )->toContain( '<h1>Title</h1>' );
+} );
+
+it( 'returns a table of contents from the stored sections when present', function (): void {
+	$policy = PrivacyPolicy::factory()->create( [
+		'content'  => "# Hidden\n\nBody",
+		'sections' => [
+			[ 'heading' => 'Visible', 'slug' => 'visible', 'level' => 2 ],
+		],
+	] );
+
+	expect( $policy->tableOfContents() )->toBe( [
+		[ 'heading' => 'Visible', 'slug' => 'visible', 'level' => 2 ],
+	] );
+} );
+
+it( 'falls back to extracting from content when sections are empty', function (): void {
+	$policy = PrivacyPolicy::factory()->create( [
+		'content'  => "# One\n\n## Two",
+		'sections' => null,
+	] );
+
+	expect( $policy->tableOfContents() )->toHaveCount( 2 );
+} );
+
+it( 'produces a sortable version key', function (): void {
+	$ten  = PrivacyPolicy::factory()->make( [ 'version' => '1.10.0' ] );
+	$nine = PrivacyPolicy::factory()->make( [ 'version' => '1.9.0' ] );
+
+	expect( $ten->versionSortKey() > $nine->versionSortKey() )->toBeTrue();
+} );

--- a/tests/Feature/Services/PrivacyPolicyGeneratorTest.php
+++ b/tests/Feature/Services/PrivacyPolicyGeneratorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use ArtisanPackUI\Privacy\Services\PrivacyPolicyGenerator;
+
+it( 'generates a draft policy using the GDPR template', function (): void {
+	config()->set( 'artisanpack.privacy.breach.organization.name', 'Acme Co.' );
+	config()->set( 'artisanpack.privacy.breach.organization.contact', 'privacy@acme.test' );
+	config()->set( 'artisanpack.privacy.breach.dpo.email', 'dpo@acme.test' );
+
+	$policy = ( new PrivacyPolicyGenerator() )->generate( [
+		'regulation' => 'gdpr',
+		'version'    => '1.0.0',
+		'locale'     => 'en',
+	] );
+
+	expect( $policy )->toBeInstanceOf( PrivacyPolicy::class );
+	expect( $policy->regulation )->toBe( 'gdpr' );
+	expect( $policy->active )->toBeFalse();
+	expect( $policy->published_at )->toBeNull();
+	expect( $policy->content )->toContain( 'Acme Co.' );
+	expect( $policy->content )->toContain( 'dpo@acme.test' );
+	expect( $policy->content )->not->toContain( '{{company_name}}' );
+	expect( $policy->sections )->not->toBeEmpty();
+} );
+
+it( 'strips conditional blocks when their placeholder is empty', function (): void {
+	$generator = new PrivacyPolicyGenerator();
+
+	$rendered = $generator->renderTemplate(
+		'Hello {{name}}!{{#extra}} Extra: {{extra}}{{/extra}}',
+		[ 'name' => 'World', 'extra' => '' ],
+	);
+
+	expect( $rendered )->toBe( 'Hello World!' );
+
+	$renderedWithExtra = $generator->renderTemplate(
+		'Hello {{name}}!{{#extra}} Extra: {{extra}}{{/extra}}',
+		[ 'name' => 'World', 'extra' => 'yes' ],
+	);
+
+	expect( $renderedWithExtra )->toBe( 'Hello World! Extra: yes' );
+} );
+
+it( 'extracts the section outline used by the table of contents', function (): void {
+	$sections = ( new PrivacyPolicyGenerator() )->extractSections(
+		"# Title\n\n## Section A\n\nSome text.\n\n## Section B",
+	);
+
+	expect( $sections )->toHaveCount( 3 );
+	expect( $sections[1] )->toMatchArray( [
+		'heading' => 'Section A',
+		'slug'    => 'section-a',
+		'level'   => 2,
+	] );
+} );
+
+it( 'activates the policy when activate=true is passed', function (): void {
+	$policy = ( new PrivacyPolicyGenerator() )->generate( [
+		'regulation' => 'ccpa',
+		'activate'   => true,
+	] );
+
+	expect( $policy->active )->toBeTrue();
+	expect( $policy->published_at )->not->toBeNull();
+} );
+
+it( 'falls back to the general template for unknown regulations', function (): void {
+	$policy = ( new PrivacyPolicyGenerator() )->generate( [
+		'regulation' => 'unknown_regulation',
+	] );
+
+	expect( $policy->regulation )->toBe( 'general' );
+	expect( $policy->content )->toContain( 'Privacy Policy' );
+} );

--- a/tests/Feature/Services/ReconsentServiceTest.php
+++ b/tests/Feature/Services/ReconsentServiceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Privacy\Events\PolicyReconsentGiven;
+use ArtisanPackUI\Privacy\Events\PolicyReconsentRequired;
+use ArtisanPackUI\Privacy\Models\Consent;
+use ArtisanPackUI\Privacy\Models\PrivacyPolicy;
+use ArtisanPackUI\Privacy\Services\ReconsentService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Tests\Support\TestSubject;
+
+beforeEach( function (): void {
+	Schema::create( 'test_subjects', function ( Blueprint $table ): void {
+		$table->id();
+		$table->string( 'name' )->nullable();
+		$table->string( 'email' )->nullable();
+	} );
+} );
+
+afterEach( function (): void {
+	Schema::dropIfExists( 'test_subjects' );
+} );
+
+it( 'returns up-to-date when no active policy requires reconsent', function (): void {
+	$subject = TestSubject::create();
+	$service = app( ReconsentService::class );
+
+	expect( $service->isUpToDate( $subject ) )->toBeTrue();
+
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => false,
+		'version'            => '1.0.0',
+	] );
+
+	expect( $service->isUpToDate( $subject ) )->toBeTrue();
+} );
+
+it( 'flags a user with stale consent as out-of-date', function (): void {
+	$subject = TestSubject::create();
+
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	$service = app( ReconsentService::class );
+
+	expect( $service->isUpToDate( $subject ) )->toBeFalse();
+} );
+
+it( 'records re-consent by updating policy_version on consent rows', function (): void {
+	$subject = TestSubject::create();
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+
+	$policy = PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	Event::fake();
+
+	$service = app( ReconsentService::class );
+	$updated = $service->grant( $policy, $subject );
+
+	expect( $updated )->toBe( 1 );
+	expect( $service->isUpToDate( $subject ) )->toBeTrue();
+	Event::assertDispatched( PolicyReconsentGiven::class );
+} );
+
+it( 'respects the grace period before blocking', function (): void {
+	config()->set( 'artisanpack.privacy.policy.block_on_no_reconsent', true );
+	config()->set( 'artisanpack.privacy.policy.reconsent_grace_period_days', 30 );
+
+	$subject = TestSubject::create();
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+		'published_at'       => now()->subDays( 10 ),
+	] );
+
+	$service = app( ReconsentService::class );
+
+	expect( $service->isBlocked( $subject ) )->toBeFalse();
+} );
+
+it( 'blocks once the grace period elapses', function (): void {
+	config()->set( 'artisanpack.privacy.policy.block_on_no_reconsent', true );
+	config()->set( 'artisanpack.privacy.policy.reconsent_grace_period_days', 5 );
+
+	$subject = TestSubject::create();
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'policy_version'   => '0.9.0',
+	] );
+
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+		'published_at'       => now()->subDays( 30 ),
+	] );
+
+	$service = app( ReconsentService::class );
+
+	expect( $service->isBlocked( $subject ) )->toBeTrue();
+} );
+
+it( 'fires PolicyReconsentRequired when notifyRequired is called', function (): void {
+	Event::fake();
+
+	$policy = PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	app( ReconsentService::class )->notifyRequired( $policy );
+
+	Event::assertDispatched( PolicyReconsentRequired::class );
+} );

--- a/tests/Feature/Services/ReconsentServiceTest.php
+++ b/tests/Feature/Services/ReconsentServiceTest.php
@@ -24,6 +24,69 @@ afterEach( function (): void {
 	Schema::dropIfExists( 'test_subjects' );
 } );
 
+it( 'resolves a regulation-tagged active policy even when the caller passes no regulation', function (): void {
+	PrivacyPolicy::factory()->active()->create( [
+		'regulation'         => 'gdpr',
+		'version'            => '1.0.0',
+		'requires_reconsent' => true,
+	] );
+
+	$service = app( ReconsentService::class );
+
+	expect( $service->currentPolicy()?->version )->toBe( '1.0.0' );
+	expect( $service->currentPolicy( 'gdpr' )?->version )->toBe( '1.0.0' );
+} );
+
+it( 'treats users with no consent rows as up-to-date so brand-new users don\'t see a reconsent prompt', function (): void {
+	PrivacyPolicy::factory()->active()->create( [
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	$subject = TestSubject::create();
+
+	expect( app( ReconsentService::class )->isUpToDate( $subject ) )->toBeTrue();
+} );
+
+it( 'scopes grant() to the policy\'s regulation and skips withdrawn consents', function (): void {
+	$subject = TestSubject::create();
+
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'regulation'       => 'gdpr',
+		'category'         => 'analytics',
+		'policy_version'   => '0.9.0',
+	] );
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'regulation'       => 'ccpa',
+		'category'         => 'sale',
+		'policy_version'   => '0.5.0',
+	] );
+	Consent::factory()->create( [
+		'consentable_type' => $subject->getMorphClass(),
+		'consentable_id'   => $subject->getKey(),
+		'regulation'       => 'gdpr',
+		'category'         => 'marketing',
+		'policy_version'   => '0.9.0',
+		'withdrawn_at'     => now()->subDay(),
+	] );
+
+	$policy = PrivacyPolicy::factory()->active()->create( [
+		'regulation'         => 'gdpr',
+		'requires_reconsent' => true,
+		'version'            => '1.0.0',
+	] );
+
+	$updated = app( ReconsentService::class )->grant( $policy, $subject );
+
+	expect( $updated )->toBe( 1 );
+	expect( Consent::query()->where( 'regulation', 'ccpa' )->first()->policy_version )->toBe( '0.5.0' );
+	expect( Consent::query()->whereNotNull( 'withdrawn_at' )->first()->policy_version )->toBe( '0.9.0' );
+} );
+
 it( 'returns up-to-date when no active policy requires reconsent', function (): void {
 	$subject = TestSubject::create();
 	$service = app( ReconsentService::class );


### PR DESCRIPTION
## Description

Bundles five small, closely-related Phase 8/9 issues (#36, #37, #38, #39, #40) into a single PR. The work covers the full policy lifecycle (generation → display → re-consent) plus a broader UI customization surface that brings React and Vue parity to the new re-consent banner.

**Closes:** #36, #37, #38, #39, #40

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #36, #37, #38, #39, #40

## Motivation and Context

#36 and #37 needed each other (a model + service that produces records, and the templates that feed them). #38 is unusable without #36/#37, and #39 layers on top of all three. #40 was framed around the existing CookieBanner but turned out to be the right place to apply the same customization story to the new re-consent banner.

The issues were filed before the React/Vue pivot, so the new Livewire component ships with matching React (`PolicyReconsentBanner.tsx`) and Vue (`PolicyReconsentBanner.vue`) equivalents from day one.

## Changes Made

- **#36** — `PrivacyPolicyGenerator` service + `publish()` / `unpublish()` / `renderHtml()` / `tableOfContents()` on the `PrivacyPolicy` model. Atomic publish swaps the active row per regulation+locale.
- **#37** — Markdown templates for GDPR (10 sections), CCPA (8 sections), LGPD, PIPEDA, and a general fallback. Supports ``{{placeholder}}`` substitution and ``{{#optional}}…{{/optional}}`` conditional blocks. Publishable via ``--tag=privacy-policy-templates``.
- **#38** — `PrivacyPolicyController` + ``GET /privacy/policy`` and ``GET /privacy/policy/{version}`` routes; published Blade view with table of contents, version history, language switcher, print stylesheet, and CSS-variable theming.
- **#39** — `ReconsentService`, `EnsureUpToDateConsent` middleware (`privacy.reconsent` alias), `ReconsentController`, `PolicyReconsentRequired` / `PolicyReconsentGiven` events, `LogPolicyReconsent` listener, additive migration adding `policy_version` to `privacy_consents`, and `policy.reconsent_grace_period_days` / `policy.block_on_no_reconsent` config.
- **#40** — `ui.animation`, `ui.z_index`, `ui.custom_css_class`, `ui.use_daisyui` config; `class` / `buttonClasses` / `labels` props on the Cookie banner and new re-consent banner; ``slot:header`` / ``slot:description`` / ``slot:footer`` parity; publishable CSS-variable map at `resources/css/privacy.css` via `--tag=privacy-css`.
- **React + Vue** — `PolicyReconsentBanner.tsx` and `PolicyReconsentBanner.vue` mirror the Livewire component (and slot story) and post to the same `POST /privacy/reconsent` endpoint.
- **Dependencies** — adds direct require on `league/commonmark` ^2.4 (only a `suggest` of laravel/framework on Laravel 10/11/12).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- PHP Version: 8.4
- Project Version: 1.0.0 (release branch)

**Tests Performed:**
1. ``./vendor/bin/pest`` — full suite (381 tests / 979 assertions) all green.
2. ``./vendor/bin/php-cs-fixer fix --dry-run --diff`` — clean.
3. ``./vendor/bin/phpcs`` — clean.
4. Manual sweep via the dev-app test surface at ``/privacy-test/policy``: generated policies for each regulation, exercised ``/privacy/policy`` + version history, staged re-consent for an authenticated user, accepted via Livewire / React / Vue banners, verified the customised cookie banner renders with custom labels + classes.

## Accessibility Tests Run

- [x] Keyboard navigation tested (re-consent banner uses ``role=alertdialog`` aria-modal=false; focusable buttons; no focus traps)
- [ ] Screen reader tested (Blade markup-only review; manual reader sweep deferred to integration phase)
- [x] Color contrast verified (CSS variable defaults match existing daisyUI tokens)
- [x] ARIA labels checked (banner is labelled by ``#privacy-reconsent-title``; policy page exposes the TOC under a labelled ``<nav>``)

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Feature/Services/PrivacyPolicyGeneratorTest.php` (5 tests) — placeholder substitution, conditional blocks, section extraction, activate flag, unknown-regulation fallback.
- `tests/Feature/Models/PrivacyPolicyPublishingTest.php` (8 tests) — atomic publish, regulation isolation, NULL-regulation publish swap, HTML rendering with raw-HTML escape, TOC behaviour, render sanitisation.
- `tests/Feature/Http/Controllers/PrivacyPolicyControllerTest.php` (5 tests) — 404, current policy, version routing, unknown-version 404, regulation-specific preference.
- `tests/Feature/Services/ReconsentServiceTest.php` (9 tests) — regulation lookup, no-consent semantic, regulation-scoped grant, withdrawn-row skip, up-to-date / stale detection, grant updates, grace period start/end, required-event firing.
- `tests/Feature/Http/ReconsentRoutesTest.php` (5 tests) — happy path, off-host redirect rejection, on-host redirect honoured, stale-version 409, guest 401.
- `tests/Feature/Livewire/PolicyReconsentBannerTest.php` (4 tests) — hides when no policy, shows when stale, persists acceptance, forwards customization props.

## Review Pass

Ran an internal high-effort code review (8 finder angles + verification) on the initial implementation; 15 findings ranked, all addressed in a follow-up commit before opening this PR. Highlights:

- **Security** — fixed open redirect in ReconsentController; fixed stored XSS in renderHtml() via commonmark `html_input=escape`.
- **Correctness** — `currentPolicy()` now resolves regulation-tagged policies when the caller passes no regulation (previously the middleware/banner default never matched any GDPR/CCPA row); `publish()` handles `regulation IS NULL` properly; `grant()` scopes by regulation and skips withdrawn rows; middleware bypasses the block on the policy/reconsent routes themselves so blocked users always have a path forward; dropped `View::share()` (Octane leak) and deduped the `PolicyReconsentRequired` event to once per session per version.
- **Cleanup** — removed dead `versionSortKey()` + corrected the misleading `scopeLatestFirst` docblock; removed dead guest-cookie path in `ReconsentService`.

## Breaking Changes

None. The `privacy_consents.policy_version` column is added nullable; existing consent rows continue to behave as before until the next re-consent.

## Reviewer Notes

- The single bundled PR (vs. five) is intentional: the issues are tightly coupled and small. Happy to split if review feels heavy.
- The React/Vue re-consent components are deliberately presentational — they expect the host application to surface the active policy payload (Inertia prop / Livewire ``dispatch`` / shared store). The Livewire component encapsulates the full server flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Privacy policy display page with version history, locale switcher, and table of contents
  * Re-consent banner component for privacy policy updates with customizable styling
  * Pre-built privacy policy templates for GDPR, CCPA, LGPD, and PIPEDA regulations
  * Automatic access blocking after grace period when re-consent is required

* **Configuration**
  * Configurable re-consent grace period, blocking behavior, and policy versioning options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->