### PR TITLE
chore: allow Livewire v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-14
+
+### Changed
+
+- Widen `livewire/livewire` constraint to `^3.5|^4.0` so the package installs alongside downstream apps that have already upgraded to Livewire v4. The `Livewire::component()` registration API used by `PrivacyServiceProvider` is compatible across both major versions. Applications embedding the package's Livewire components should still verify their own upgrade path — v4 introduces breaking changes to component internals.
+
 ## [1.0.0] - 2026-06-20
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Privacy and data protection toolkit for Laravel — consent management, data subject rights, and multi-regulation compliance (GDPR, CCPA, LGPD, PIPEDA).",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\Privacy\\": "src/",
@@ -30,7 +30,7 @@
     "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
     "league/commonmark": "^2.4",
-    "livewire/livewire": "^3.5"
+    "livewire/livewire": "^3.5|^4.0"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",


### PR DESCRIPTION
## Description

Widen the `livewire/livewire` composer constraint so the privacy package installs cleanly alongside downstream apps that have already upgraded to Livewire v4. Bumps the package version to `1.0.1` and adds a CHANGELOG entry.

## Type of Change

- [x] Enhancement (improves existing functionality)

## Motivation and Context

Applications on Livewire v4 currently can't add `artisanpack-ui/privacy` without composer conflicts. The `Livewire::component()` registration API used by `PrivacyServiceProvider` is compatible across v3 and v4, so widening the constraint unblocks those consumers without requiring code changes here.

## Changes Made

- Widened `livewire/livewire` constraint from `^3.5` to `^3.5|^4.0` in `composer.json`
- Bumped package `version` to `1.0.1`
- Added `1.0.1` entry to `CHANGELOG.md` documenting the constraint change and the v4 caveat for downstream consumers

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 1.0.1

**Tests Performed:**
1. Reviewed the diff — only `composer.json` constraint, version bump, and CHANGELOG entry change
2. Confirmed `PrivacyServiceProvider` only uses `Livewire::component()`, which is API-compatible across v3 and v4

## Accessibility Tests Run

Not applicable — composer metadata change only, no UI or markup changes.

## Tests Added

No new tests — this is a composer constraint widening with no code changes. Existing test suite continues to exercise the package against Livewire v3.

## Documentation

- [x] CHANGELOG updated with 1.0.1 entry noting the constraint change and downstream v4 caveat

## Pre-Submission Checklist

- [x] Checked for other open PRs for same update
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with Livewire v4 while retaining support for Livewire v3.5.

* **Documentation**
  * Added release notes for version 1.0.1, including the expanded Livewire compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->