### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-14
+
+### Changed
+
+- Widen `livewire/livewire` constraint to `^3.5|^4.0` so the package installs alongside downstream apps that have already upgraded to Livewire v4. The `Livewire::component()` registration API used by `PrivacyServiceProvider` is compatible across both major versions. Applications embedding the package's Livewire components should still verify their own upgrade path — v4 introduces breaking changes to component internals.
+
 ## [1.0.0] - 2026-06-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Changed
 
 - Widen `livewire/livewire` constraint to `^3.5|^4.0` so the package installs alongside downstream apps that have already upgraded to Livewire v4. The `Livewire::component()` registration API used by `PrivacyServiceProvider` is compatible across both major versions. Applications embedding the package's Livewire components should still verify their own upgrade path — v4 introduces breaking changes to component internals.
+- Bump the `@artisanpack-ui/privacy` JS companion package to `1.0.1` so its version tracks the PHP package. No API changes; installers that pin the JS package to a specific version should update their pin.
+- Refresh the `docs/home.md` footer to reference v1.0.1.
 
 ## [1.0.0] - 2026-06-20
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Privacy and data protection toolkit for Laravel — consent management, data subject rights, and multi-regulation compliance (GDPR, CCPA, LGPD, PIPEDA).",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\Privacy\\": "src/",
@@ -30,7 +30,7 @@
     "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
     "league/commonmark": "^2.4",
-    "livewire/livewire": "^3.5"
+    "livewire/livewire": "^3.5|^4.0"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cbb51d5f93f4c9e0668736f795fbdd4",
+    "content-hash": "163c00889b7b7756b10740682ee722f9",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/docs/home.md
+++ b/docs/home.md
@@ -114,4 +114,4 @@ For issues, feature requests, and contributions:
 
 ---
 
-*This documentation covers Privacy v1.0.0*
+*This documentation covers Privacy v1.0.1*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@artisanpack-ui/privacy",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Client-side companion for artisanpack-ui/privacy — vanilla JS API plus React and Vue components for cookie consent management.",
 	"license": "MIT",
 	"author": {


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.0.1
- **Release Date:** 2026-07-14
- **Release Type:** Patch
- **Release Branch:** `release/1.0.1`
- **Target Branch:** `main`

## Release Summary

Patch release that widens the `livewire/livewire` composer constraint to `^3.5|^4.0` so the package installs alongside downstream apps already on Livewire v4. No behavioral changes to the package itself — the `Livewire::component()` registration API used by `PrivacyServiceProvider` is compatible across both major versions. The JS companion `@artisanpack-ui/privacy` package is bumped to `1.0.1` in lockstep, and the docs footer is refreshed to match.

## Changelog

### Changed

- Widen `livewire/livewire` constraint to `^3.5|^4.0` so the package installs alongside downstream apps that have already upgraded to Livewire v4. The `Livewire::component()` registration API used by `PrivacyServiceProvider` is compatible across both major versions. Applications embedding the package's Livewire components should still verify their own upgrade path — v4 introduces breaking changes to component internals.
- Bump the `@artisanpack-ui/privacy` JS companion package to `1.0.1` so its version tracks the PHP package. No API changes; installers that pin the JS package to a specific version should update their pin.
- Refresh the `docs/home.md` footer to reference v1.0.1.

## Issues and Pull Requests

**Related PRs:**
- #62 chore: allow Livewire v4

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

## Testing Checklist

- [x] All automated tests passing (403 tests / 1028 assertions via Pest)
- [x] Security scan completed (`composer audit` — no vulnerabilities)
- [ ] Manual testing completed
- [ ] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [ ] Tested in staging environment
- [ ] Database migrations tested (if applicable) — no migrations in this release

**Testing notes:**

Composer constraint widening only; behavior unchanged. Full Pest suite (403 tests) passing against Livewire v3.8.1. Verification against a Livewire v4 install is deferred to downstream apps upgrading their own Livewire major.

## Documentation Checklist

- [x] CHANGELOG updated (1.0.1 entry with Changed items)
- [x] docs/home.md footer refreshed to v1.0.1
- [ ] README updated (if needed) — no changes needed
- [ ] API documentation updated (if needed) — no API changes
- [ ] Migration guide written (if breaking changes) — no breaking changes
- [ ] Release notes written
- [ ] Wiki updated (if applicable)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json` 1.0.1, `package.json` 1.0.1, `docs/home.md` v1.0.1)
- [ ] Git tag prepared: `v1.0.1`
- [x] Release branch created/updated: `release/1.0.1`
- [x] Dependencies updated and tested (`composer.lock` in sync, `composer audit` clean)
- [ ] Build artifacts generated
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

**Dependency audit notes:**

- `composer audit` — no vulnerability advisories.
- `composer outdated --direct` — 6 direct deps behind, none blocking this patch:
  - `friendsofphp/php-cs-fixer` 3.95.8 → 3.95.13 (patch, dev)
  - `league/commonmark` 2.8.2 → 2.8.3 (patch)
  - `livewire/livewire` 3.8.1 → 4.3.3 (major, intentionally deferred — this release only widens the constraint)
  - `orchestra/testbench` 10.11.0 → 11.1.0 (major, dev)
  - `pestphp/pest` 3.8.6 → 4.7.5 (major, dev)
  - `pestphp/pest-plugin-laravel` 3.2.0 → 4.1.0 (major, dev)

## Deployment

**Deployment steps:**
1. Merge this PR to `main`.
2. Tag `v1.0.1` on the merge commit.
3. Push the tag; Packagist picks up the new version.

**Rollback plan:**
1. Downstream apps can pin `artisanpack-ui/privacy` to `1.0.0` if they hit issues.

## Post-Release Tasks

- [ ] Tag created: `v1.0.1`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

Prepared by the `/prepare-release` skill. See #62 for the underlying Livewire constraint widening PR.

---

**Release Manager:** @ViewFromTheBox

**For Reviewers:**
- Verify all checklist items completed
- Review changelog accuracy
- Confirm version numbers correct (composer.json, package.json, docs/home.md all on 1.0.1)
- Confirm no breaking changes