### PR TITLE
refactor: normalize all privacy.* hooks to ap.privacy.* camelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-20
+
+### Changed
+
+- Normalized all `privacy.*` hooks to `ap.privacy.*` camelCase per the cross-package hooks convention. 11 canonical hooks, 12 aliases registered (both `privacy.export.data` and `privacy.export-data` legacy spellings collapse to `ap.privacy.exportData`). Existing subscribers continue firing via `HookDeprecations` aliases — each emits an info-level log the first time it resolves per request. Alias removal deferred to next major.
+- Bumped `artisanpack-ui/hooks` to `^1.3`.
+
 ## [1.0.1] - 2026-07-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -135,6 +135,43 @@ composer test                                # full suite
 
 The package ships with 400+ Pest tests covering all services, models, Livewire components, Artisan commands, middleware, events, and listeners.
 
+## Hooks
+
+The package fires the following canonical hooks (`ap.privacy.*` camelCase, per the cross-package hooks convention):
+
+| Hook | Type |
+|---|---|
+| `ap.privacy.exportData` | filter |
+| `ap.privacy.exportFormats` | filter |
+| `ap.privacy.formatExport` | filter |
+| `ap.privacy.deleteData` | action |
+| `ap.privacy.anonymizeData` | filter |
+| `ap.privacy.hasData` | filter |
+| `ap.privacy.dataSummary` | filter |
+| `ap.privacy.consentGranted` | action |
+| `ap.privacy.consentRevoked` | action |
+| `ap.privacy.consentStatus` | filter |
+| `ap.privacy.consentCategories` | filter |
+
+### Deprecated Hooks
+
+The following legacy hook names remain registered as backwards-compatibility aliases via `HookDeprecations`. Subscribers to any of the old names continue to fire — each emits an info-level log the first time it resolves per request. **Alias removal is deferred to the next major.**
+
+| Deprecated | Canonical |
+|---|---|
+| `privacy.export.data` | `ap.privacy.exportData` |
+| `privacy.export-data` | `ap.privacy.exportData` |
+| `privacy.export-formats` | `ap.privacy.exportFormats` |
+| `privacy.export-format` | `ap.privacy.formatExport` |
+| `privacy.delete-data` | `ap.privacy.deleteData` |
+| `privacy.anonymize-data` | `ap.privacy.anonymizeData` |
+| `privacy.has-data` | `ap.privacy.hasData` |
+| `privacy.data-summary` | `ap.privacy.dataSummary` |
+| `privacy.consent-granted` | `ap.privacy.consentGranted` |
+| `privacy.consent-revoked` | `ap.privacy.consentRevoked` |
+| `privacy.consent-status` | `ap.privacy.consentStatus` |
+| `privacy.consent-categories` | `ap.privacy.consentCategories` |
+
 ## Upgrading
 
 See [UPGRADING.md](UPGRADING.md) for version-to-version migration notes.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Privacy and data protection toolkit for Laravel — consent management, data subject rights, and multi-regulation compliance (GDPR, CCPA, LGPD, PIPEDA).",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\Privacy\\": "src/",
@@ -29,6 +29,7 @@
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
+    "artisanpack-ui/hooks": "^1.3",
     "league/commonmark": "^2.4",
     "livewire/livewire": "^3.5|^4.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "163c00889b7b7756b10740682ee722f9",
+    "content-hash": "79cc7859b4726abb292062a183486455",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -74,6 +74,72 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "artisanpack-ui/hooks",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
+            },
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "brick/math",

--- a/src/PrivacyServiceProvider.php
+++ b/src/PrivacyServiceProvider.php
@@ -68,6 +68,7 @@ use ArtisanPackUI\Privacy\Services\PersonalDataScanner;
 use ArtisanPackUI\Privacy\Services\PrivacyPolicyGenerator;
 use ArtisanPackUI\Privacy\Services\ReconsentService;
 use ArtisanPackUI\Privacy\Services\VerificationService;
+use ArtisanPackUI\Privacy\Support\HookAliases;
 use ArtisanPackUI\Privacy\View\PrivacyDirectives;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -210,6 +211,8 @@ class PrivacyServiceProvider extends ServiceProvider
 	 */
 	public function boot(): void
 	{
+		HookAliases::register();
+
 		$this->publishes( [
 			__DIR__ . '/../config/artisanpack/privacy.php'
 				 => config_path( 'artisanpack/privacy.php' ),

--- a/src/Services/DataExportService.php
+++ b/src/Services/DataExportService.php
@@ -10,7 +10,7 @@
  *
  * Other packages can append sections to the payload by listening for the
  * {@see DataExportCollecting} event, or — when the `artisanpack-ui/hooks`
- * package is installed — by registering an `addFilter('privacy.export.data', …)`
+ * package is installed — by registering an `addFilter('ap.privacy.exportData', …)`
  * filter that receives `($data, $subject)` and returns the mutated array.
  *
  * @package    ArtisanPack_UI
@@ -243,7 +243,7 @@ class DataExportService
 		$data = $event->data;
 
 		if ( function_exists( 'applyFilters' ) ) {
-			$data = (array) applyFilters( 'privacy.export.data', $data, $subject );
+			$data = (array) applyFilters( 'ap.privacy.exportData', $data, $subject );
 		}
 
 		return $data;

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Registers backwards-compatibility aliases for renamed Privacy hooks.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Privacy\Support;
+
+/**
+ * Registers deprecated hook aliases for the Privacy package so existing
+ * subscribers to the legacy `privacy.*` names continue firing while
+ * canonical fires migrate to the `ap.privacy.*` camelCase convention.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Privacy
+ *
+ * @since      1.1.0
+ */
+class HookAliases
+{
+	/**
+	 * Registers all legacy → canonical hook aliases via HookDeprecations.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return void
+	 */
+	public static function register(): void
+	{
+		if ( ! function_exists( 'deprecateHook' ) ) {
+			return;
+		}
+
+		deprecateHook( 'privacy.export.data',        'ap.privacy.exportData' );
+		deprecateHook( 'privacy.export-data',        'ap.privacy.exportData' );
+		deprecateHook( 'privacy.export-formats',     'ap.privacy.exportFormats' );
+		deprecateHook( 'privacy.export-format',      'ap.privacy.formatExport' );
+		deprecateHook( 'privacy.delete-data',        'ap.privacy.deleteData' );
+		deprecateHook( 'privacy.anonymize-data',     'ap.privacy.anonymizeData' );
+		deprecateHook( 'privacy.has-data',           'ap.privacy.hasData' );
+		deprecateHook( 'privacy.data-summary',       'ap.privacy.dataSummary' );
+		deprecateHook( 'privacy.consent-granted',    'ap.privacy.consentGranted' );
+		deprecateHook( 'privacy.consent-revoked',    'ap.privacy.consentRevoked' );
+		deprecateHook( 'privacy.consent-status',     'ap.privacy.consentStatus' );
+		deprecateHook( 'privacy.consent-categories', 'ap.privacy.consentCategories' );
+	}
+}

--- a/tests/Feature/Support/HookAliasesTest.php
+++ b/tests/Feature/Support/HookAliasesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types=1 );
+
+it( 'fires legacy subscribers via alias', function ( string $oldName, string $newName ): void {
+    $ran = false;
+
+    addFilter( $oldName, function ( $value ) use ( &$ran ) {
+        $ran = true;
+        return $value;
+    } );
+
+    applyFilters( $newName, 'seed' );
+
+    removeAllFilters( $oldName );
+    removeAllFilters( $newName );
+
+    expect( $ran )->toBeTrue();
+} )->with( [
+    [ 'privacy.export.data',        'ap.privacy.exportData' ],
+    [ 'privacy.export-data',        'ap.privacy.exportData' ],
+    [ 'privacy.export-formats',     'ap.privacy.exportFormats' ],
+    [ 'privacy.export-format',      'ap.privacy.formatExport' ],
+    [ 'privacy.delete-data',        'ap.privacy.deleteData' ],
+    [ 'privacy.anonymize-data',     'ap.privacy.anonymizeData' ],
+    [ 'privacy.has-data',           'ap.privacy.hasData' ],
+    [ 'privacy.data-summary',       'ap.privacy.dataSummary' ],
+    [ 'privacy.consent-granted',    'ap.privacy.consentGranted' ],
+    [ 'privacy.consent-revoked',    'ap.privacy.consentRevoked' ],
+    [ 'privacy.consent-status',     'ap.privacy.consentStatus' ],
+    [ 'privacy.consent-categories', 'ap.privacy.consentCategories' ],
+] );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace Tests;
 
+use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
 use ArtisanPackUI\Privacy\PrivacyServiceProvider;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -44,6 +45,7 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders( $app ): array
     {
         $providers = [
+            HooksServiceProvider::class,
             PrivacyServiceProvider::class,
         ];
 


### PR DESCRIPTION
## Description

Normalizes all 11 `privacy.*` hooks to `ap.privacy.*` camelCase per the cross-package hooks convention. Registers 12 backwards-compat aliases via `HookDeprecations` (both `privacy.export.data` and `privacy.export-data` legacy spellings collapse to `ap.privacy.exportData`). Existing subscribers continue firing — each unique alias emits an info-level log the first time it resolves per request. Alias removal deferred to next major.

**Closes:** #64

## Type of Change

- [x] Refactoring (code improvement, no behavior change)
- [x] Breaking change (breaks backward compatibility) — mitigated by deprecation aliases

## Related Issue

**Issue:** #64

## Motivation and Context

Cross-package hooks standardization (umbrella hooks#13, Wave 1). Every privacy hook currently fires with no `ap.` prefix and kebab-case sub-segments — violates the new convention on both counts. Coordinated with analytics #82, which subscribes to these hooks (its subscriptions keep working via aliases; a follow-up will update its \`addFilter\` calls to the new names).

## Changes Made

- Bumped \`artisanpack-ui/hooks\` requirement to \`^1.3\`
- Renamed the sole live fire site in \`src/Services/DataExportService.php\` (line ~246) from \`privacy.export.data\` to \`ap.privacy.exportData\`
- Added \`src/Support/HookAliases.php\` registering all 12 aliases per the map below
- Wired \`HookAliases::register()\` first thing in \`PrivacyServiceProvider::boot()\`
- Added data-driven \`tests/Feature/Support/HookAliasesTest.php\` covering all 12 aliases
- Registered \`HooksServiceProvider\` in \`tests/TestCase.php\` (Testbench doesn't auto-discover)
- Added new "Hooks" + "Deprecated Hooks" sections to README (none existed before)
- Updated CHANGELOG (1.1.0 entry)
- Bumped version \`1.0.1\` → \`1.1.0\`

## Rename Map

| Old | New |
|---|---|
| \`privacy.export.data\` | \`ap.privacy.exportData\` |
| \`privacy.export-data\` | \`ap.privacy.exportData\` |
| \`privacy.export-formats\` | \`ap.privacy.exportFormats\` |
| \`privacy.export-format\` | \`ap.privacy.formatExport\` |
| \`privacy.delete-data\` | \`ap.privacy.deleteData\` |
| \`privacy.anonymize-data\` | \`ap.privacy.anonymizeData\` |
| \`privacy.has-data\` | \`ap.privacy.hasData\` |
| \`privacy.data-summary\` | \`ap.privacy.dataSummary\` |
| \`privacy.consent-granted\` | \`ap.privacy.consentGranted\` |
| \`privacy.consent-revoked\` | \`ap.privacy.consentRevoked\` |
| \`privacy.consent-status\` | \`ap.privacy.consentStatus\` |
| \`privacy.consent-categories\` | \`ap.privacy.consentCategories\` |

## Notes

Only \`privacy.export.data\` (in \`DataExportService\`) has a live fire site today. The other 10 canonical names have no current fires, but all 12 aliases are still registered per spec so future/downstream code can adopt them safely.

## How Has This Been Tested?

**Tests Performed:**
1. \`./vendor/bin/pest\` — 415 passed, 1040 assertions (includes 12 new data-driven alias tests)
2. Manual verification via \`/packages/hooks/wave-one-renames\` in the dev app (all 12 alias rows green)

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

## Documentation

- [x] README updated (new Hooks + Deprecated Hooks sections)
- [x] CHANGELOG updated